### PR TITLE
Fix lockcells being ignored for LaTeX and grob output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # condformat 0.10.1.9000
 
+## Fixes
+
+* Fix `lockcells = TRUE` being ignored (or worse, unlocking cells) for LaTeX
+  and grob/gtable output in `rule_fill_discrete()`, `rule_fill_gradient()`,
+  `rule_fill_gradient2()`, `rule_text_bold()` and `rule_text_color()`. HTML
+  and Excel output were not affected.
+
 # condformat 0.10.1
 
 ## Fixes

--- a/R/rule_fill_discrete.R
+++ b/R/rule_fill_discrete.R
@@ -125,7 +125,7 @@ cf_field_to_latex.cf_field_rule_fill_solid <- function(cf_field, xview, unlocked
     function(x) sprintf("\\cellcolor[HTML]{%02X%02X%02X}", x[1],x[2],x[3]))
   after <- matrix("", nrow = nrow(colours), ncol = ncol(colours))
   if (cf_field[["lock_cells"]]) {
-    unlocked <- unlocked | to_lock
+    unlocked <- unlocked & !to_lock
   }
   list(before = before, after = after, unlocked = unlocked)
 }
@@ -146,6 +146,9 @@ cf_field_to_gtable.cf_field_rule_fill_solid <- function(cf_field, xview, gridobj
     fill <- grDevices::col2rgb(colours[row_col[tocolor, 1], row_col[tocolor, 2]])
     fill <- sprintf("#%02X%02X%02X", fill[1], fill[2], fill[3])
     gridobj$grobs[ind][[1]][["gp"]] <- grid::gpar(fill = fill)
+  }
+  if (cf_field[["lock_cells"]]) {
+    unlocked <- unlocked & !to_lock
   }
   list(gridobj = gridobj, unlocked = unlocked)
 }

--- a/R/rule_text_bold.R
+++ b/R/rule_text_bold.R
@@ -71,7 +71,7 @@ cf_field_to_latex.cf_field_rule_text_bold <- function(cf_field, xview, unlocked)
   after <- ifelse(css_values == "bold", "}", "")
 
   if (cf_field[["lock_cells"]]) {
-    unlocked <- unlocked | to_lock
+    unlocked <- unlocked & !to_lock
   }
   list(before = before, after = after, unlocked = unlocked)
 }
@@ -94,7 +94,7 @@ cf_field_to_gtable.cf_field_rule_text_bold <- function(cf_field, xview, gridobj,
   }
 
   if (cf_field[["lock_cells"]]) {
-    unlocked <- unlocked | to_lock
+    unlocked <- unlocked & !to_lock
   }
   list(gridobj = gridobj, unlocked = unlocked)
 }

--- a/R/rule_text_color.R
+++ b/R/rule_text_color.R
@@ -74,7 +74,7 @@ cf_field_to_latex.cf_field_rule_text_color <- function(cf_field, xview, unlocked
   after[nchar(css_values) > 0 ] <- "}"
 
   if (cf_field[["lock_cells"]]) {
-    unlocked <- unlocked | to_lock
+    unlocked <- unlocked & !to_lock
   }
   list(before = before, after = after, unlocked = unlocked)
 }
@@ -95,7 +95,7 @@ cf_field_to_gtable.cf_field_rule_text_color <- function(cf_field, xview, gridobj
   }
 
   if (cf_field[["lock_cells"]]) {
-    unlocked <- unlocked | to_lock
+    unlocked <- unlocked & !to_lock
   }
   list(gridobj = gridobj, unlocked = unlocked)
 }

--- a/tests/testthat/test-rule-fill-discrete.R
+++ b/tests/testthat/test-rule-fill-discrete.R
@@ -98,3 +98,23 @@ test_that("rule_fill_discrete gtable works", {
   expect_equal(cfg$grobs[[16]]$gp$fill, "#619CFF")
   vdiffr::expect_doppelganger(title = "rule_fill_discrete gtable", cfg)
 })
+
+test_that("rule_fill_discrete lockcells prevents further LaTeX rules from applying", {
+  out <- data.frame(a = "Dog") %>%
+    condformat() %>%
+    rule_fill_discrete("a", colours = c("Dog" = "#FF0000"), lockcells = TRUE) %>%
+    rule_fill_discrete("a", colours = c("Dog" = "#0000FF")) %>%
+    condformat2latex()
+  expect_true(grepl("FF0000", out, fixed = TRUE))
+  expect_false(grepl("0000FF", out, fixed = TRUE))
+})
+
+test_that("rule_fill_discrete lockcells prevents further gtable rules from applying", {
+  cfg <- data.frame(a = "Dog") %>%
+    condformat() %>%
+    rule_fill_discrete("a", colours = c("Dog" = "#FF0000"), lockcells = TRUE) %>%
+    rule_fill_discrete("a", colours = c("Dog" = "#0000FF")) %>%
+    condformat2grob(draw = FALSE)
+  ind <- find_cell(cfg, 2, 2, name = "core-bg")
+  expect_equal(cfg$grobs[ind][[1]][["gp"]][["fill"]], "#FF0000")
+})

--- a/tests/testthat/test-rule-text-bold.R
+++ b/tests/testthat/test-rule-text-bold.R
@@ -18,3 +18,13 @@ test_that("rule_text_bold works for LaTeX output", {
     strsplit(split = "\n", fixed = TRUE)
   expect_true(any(grepl(pattern = "\\textbf{potato}", x[[1]], fixed = TRUE)))
 })
+
+test_that("rule_text_bold lockcells prevents further LaTeX rules from applying", {
+  out <- condformat(data.frame(a = "potato")) %>%
+    rule_text_bold("a", expression = TRUE, lockcells = TRUE) %>%
+    rule_text_bold("a", expression = TRUE) %>%
+    condformat2latex()
+  matches <- gregexpr("\\textbf{", out, fixed = TRUE)[[1]]
+  n_matches <- if (identical(matches, -1L)) 0L else length(matches)
+  expect_equal(n_matches, 1L)
+})

--- a/tests/testthat/test-rule-text-color.R
+++ b/tests/testthat/test-rule-text-color.R
@@ -26,5 +26,5 @@ test_that("rule_text_color lockcells prevents further gtable rules from applying
     rule_text_color("a", expression = "blue") %>%
     condformat2grob(draw = FALSE)
   ind <- find_cell(cfg, 2, 2, name = "core-fg")
-  expect_equal(cfg$grobs[ind][[1]][["gp"]][["col"]], "red")
+  expect_equal(unname(cfg$grobs[ind][[1]][["gp"]][["col"]]), "red")
 })

--- a/tests/testthat/test-rule-text-color.R
+++ b/tests/testthat/test-rule-text-color.R
@@ -9,3 +9,22 @@ test_that("rule_text_color works", {
   expect_true(grepl(pattern = "\\textcolor[RGB]{0,0,255}{setosa}", out, fixed = TRUE))
   expect_false(grepl(pattern = "\\textcolor[RGB]{0,0,255}{versicolor}", out, fixed = TRUE))
 })
+
+test_that("rule_text_color lockcells prevents further LaTeX rules from applying", {
+  out <- condformat(data.frame(a = "potato")) %>%
+    rule_text_color("a", expression = "red", lockcells = TRUE) %>%
+    rule_text_color("a", expression = "blue") %>%
+    condformat2latex()
+  expect_true(grepl("RGB]{255,0,0}", out, fixed = TRUE))
+  expect_false(grepl("RGB]{0,0,255}", out, fixed = TRUE))
+})
+
+test_that("rule_text_color lockcells prevents further gtable rules from applying", {
+  cfg <- data.frame(a = "potato") %>%
+    condformat() %>%
+    rule_text_color("a", expression = "red", lockcells = TRUE) %>%
+    rule_text_color("a", expression = "blue") %>%
+    condformat2grob(draw = FALSE)
+  ind <- find_cell(cfg, 2, 2, name = "core-fg")
+  expect_equal(cfg$grobs[ind][[1]][["gp"]][["col"]], "red")
+})


### PR DESCRIPTION
## Summary
- `rule_fill_discrete()` (and by extension `rule_fill_gradient()`/`rule_fill_gradient2()`, which reuse the same `cf_field_rule_fill_solid` class), `rule_text_bold()` and `rule_text_color()` all had `unlocked <- unlocked | to_lock` in their `cf_field_to_latex()`/`cf_field_to_gtable()` methods. `|` (OR) can only ever set more cells to `unlocked = TRUE`, the opposite of what `lockcells = TRUE` documents ("no further rules should be applied to the affected cells"). The gtable method for the fill rules didn't attempt any locking at all.
- HTML and Excel output were unaffected — they go through `rule_css.R`/`rule_fill_bar.R`, which already used the correct `unlocked[mask] <- FALSE` pattern.
- Fixed all five call sites to `unlocked <- unlocked & !to_lock`, matching the working HTML/Excel implementation, and added the missing lock step to the fill-rule gtable method.

## Test plan
- [x] Added regression tests exercising `lockcells` through LaTeX output for all three rule types, and through gtable output for the fill and text-color rules (`tests/testthat/test-rule-fill-discrete.R`, `test-rule-text-bold.R`, `test-rule-text-color.R`)
- [ ] CI runs green


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_