### PR TITLE
Fix theme_htmlTable() dropping args from earlier chained calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   and grob/gtable output in `rule_fill_discrete()`, `rule_fill_gradient()`,
   `rule_fill_gradient2()`, `rule_text_bold()` and `rule_text_color()`. HTML
   and Excel output were not affected.
+* Fix `theme_htmlTable()` discarding arguments accumulated from earlier
+  `theme_htmlTable()` calls in the same pipeline, due to a `%in%` check
+  against list values instead of list names.
 
 # condformat 0.10.1
 

--- a/R/theme_htmlTable.R
+++ b/R/theme_htmlTable.R
@@ -58,7 +58,7 @@ add_theme_to_condformat <- function(x, theme) {
 
 #' @importFrom htmlTable htmlTable
 render_theme.theme_htmlTable <- function(themeobj, finaltheme, xview, ...) {
-  if (!"html" %in% finaltheme) {
+  if (!"html" %in% names(finaltheme)) {
     finaltheme[["html"]] <- list()
   }
   for (paramname in names(themeobj[["htmlargs"]])) {

--- a/tests/testthat/test-theme-htmlTable.R
+++ b/tests/testthat/test-theme-htmlTable.R
@@ -5,6 +5,15 @@ test_that("theme_htmlTable works", {
   expect_match(out, "MySimpleTestCaption")
 })
 
+test_that("theme_htmlTable args accumulate across chained calls", {
+  data(iris)
+  out <- condformat(head(iris)) %>%
+    theme_htmlTable(caption = "MyChainedCaption") %>%
+    theme_htmlTable(rnames = FALSE) %>%
+    condformat2html()
+  expect_match(out, "MyChainedCaption")
+})
+
 test_that("theme_caption works", {
   x <- data.frame(a = 1) %>% theme_caption("potato") %>% condformat2html()
   out <- strsplit(x, "\n", fixed = TRUE)[[1]]


### PR DESCRIPTION
## Summary
- `render_theme.theme_htmlTable()` (`R/theme_htmlTable.R:61`) checked `!"html" %in% finaltheme` — since `finaltheme` is a list, `%in%` matches against its *values*, never its names, so this condition was always true. Every `theme_htmlTable()` call in a pipeline therefore reset `finaltheme[["html"]]` to `list()` before merging in its own args, silently dropping args accumulated from any earlier `theme_htmlTable()` call.
- Fixed to `!"html" %in% names(finaltheme)`, matching the correct pattern already used in `theme_kable.R`, `theme_grob.R` and `theme_htmlWidget.R`.

## Test plan
- [x] Added a regression test chaining two `theme_htmlTable()` calls (`caption=` then `rnames=`) and checking the first call's `caption` survives into the rendered HTML (`tests/testthat/test-theme-htmlTable.R`)
- [ ] CI runs green


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_