### PR TITLE
Fix rule_fill_bar() na.value dead code, a 0%-width crash, and lockcells gaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@
 * Fix `rule_fill_bar()` erroring in grob/gtable output when a value rescaled
   to exactly 0% of the bar width (`colorRampPalette()` can't return zero
   colours); such cells now render with just the background colour.
+* Fix `rule_fill_bar()`'s `lockcells = TRUE` not protecting NA cells from
+  later CSS/HTML rules, and not protecting any cell (NA or not) from later
+  grob/gtable rules: the grob/gtable renderer painted every targeted cell
+  unconditionally and never checked incoming lock state at all.
 
 # condformat 0.10.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@
 * Fix `theme_htmlTable()` discarding arguments accumulated from earlier
   `theme_htmlTable()` calls in the same pipeline, due to a `%in%` check
   against list values instead of list names.
+* Fix `rule_fill_bar()`'s `na.value` never being applied to `background-color`
+  in HTML output: the CSS mask used to gate that assignment already excluded
+  NA cells, so the assignment was dead code.
+* Fix `rule_fill_bar()` erroring in grob/gtable output when a value rescaled
+  to exactly 0% of the bar width (`colorRampPalette()` can't return zero
+  colours); such cells now render with just the background colour.
 
 # condformat 0.10.1
 

--- a/R/rule_fill_bar.R
+++ b/R/rule_fill_bar.R
@@ -173,6 +173,7 @@ cf_field_to_css.cf_field_rule_bar_gradient <- function(cf_field, xview, css_fiel
 
   if (identical(cf_field[["lock_cells"]], TRUE)) {
     unlocked[mask] <- FALSE
+    unlocked[na_cell] <- FALSE
   }
   return(list(css_fields = css_fields, unlocked = unlocked))
 }
@@ -202,6 +203,9 @@ cf_field_to_gtable.cf_field_rule_bar_gradient <- function(
 
   row_col <- which(!is.na(pbar_is_na), arr.ind = TRUE)
   for (tocolor in seq_len(nrow(row_col))) {
+    if (!unlocked[row_col[tocolor, 1], row_col[tocolor, 2]]) {
+      next
+    }
     ind <- find_cell(gridobj,
                      as.integer(has_colnames) + row_col[tocolor, 1],
                      as.integer(has_rownames) + row_col[tocolor, 2],
@@ -243,7 +247,12 @@ cf_field_to_gtable.cf_field_rule_bar_gradient <- function(
   }
 
   if (identical(cf_field[["lock_cells"]], TRUE)) {
+    # `mask` already excludes NA cells; lock those separately, cleaning the
+    # raw NA that pbar_is_na holds for untargeted columns first.
+    na_cell <- pbar_is_na
+    na_cell[is.na(na_cell)] <- FALSE
     unlocked[mask] <- FALSE
+    unlocked[na_cell] <- FALSE
   }
   return(list(gridobj = gridobj, unlocked = unlocked))
 }

--- a/R/rule_fill_bar.R
+++ b/R/rule_fill_bar.R
@@ -151,7 +151,12 @@ cf_field_to_css.cf_field_rule_bar_gradient <- function(cf_field, xview, css_fiel
   col_bg <- cf_field[["col_background"]]
 
   background_color <- get_css_key(css_fields, "background-color", dim(xview))
-  background_color[mask & pbar_is_na] <- sprintf("#%02X%02X%02X", col_na[1], col_na[2], col_na[3])
+  # NA cells are excluded from `mask`, so this branch needs to be gated on
+  # `unlocked` alone. pbar_is_na holds raw NA (not FALSE) for columns the
+  # rule doesn't target, so clean that up first to avoid NA in the index.
+  na_cell <- pbar_is_na
+  na_cell[is.na(na_cell)] <- FALSE
+  background_color[unlocked & na_cell] <- sprintf("#%02X%02X%02X", col_na[1], col_na[2], col_na[3])
   background_color[mask & !pbar_is_na] <- sprintf("#%02X%02X%02X", col_bg[1], col_bg[2], col_bg[3])
   css_fields[["background-color"]] <- background_color
 
@@ -208,9 +213,16 @@ cf_field_to_gtable.cf_field_rule_bar_gradient <- function(
       #grid::removeGrob(gridobj, rect$name)
       grad_levels <- 100
       fill_to <- round(100*bar_width_percent[row_col[tocolor, 1], row_col[tocolor, 2]])
+      # colorRampPalette(...)(0) errors (it can't request zero colours), so
+      # a 0%-width bar gets no gradient colours at all, just the background.
+      if (fill_to > 0) {
+        ramp_colors <- grDevices::colorRampPalette(c(col_low, col_high), space = "Lab")(fill_to)
+      } else {
+        ramp_colors <- character(0)
+      }
       gp <- grid::gpar(col = NA,
                        fill = c(
-                         grDevices::colorRampPalette(c(col_low, col_high), space = "Lab")(fill_to),
+                         ramp_colors,
                          rep(col_bg, grad_levels - fill_to)))
       gridobj <- gtable::gtable_add_grob(gridobj,
                                          grobs = grid::rectGrob(

--- a/tests/testthat/test-rule-fill-bar.R
+++ b/tests/testthat/test-rule-fill-bar.R
@@ -113,14 +113,17 @@ test_that("rule_fill_bar gtable renders a gradient bar and a plain fill for NA c
 })
 
 test_that("rule_fill_bar gtable does not crash when a value rescales to exactly 0%", {
+  # a=1 rescales to exactly 0% under the default (data range) limits; this
+  # used to error inside colorRampPalette(..., space = "Lab")(0)
+  cfg_before <- data.frame(a = c(1, 3, 5)) %>%
+    condformat() %>%
+    condformat2grob(draw = FALSE)
   cfg <- data.frame(a = c(1, 3, 5)) %>%
     condformat() %>%
     rule_fill_bar(a) %>%
     condformat2grob(draw = FALSE)
-  ind <- find_cell(cfg, 2, 2, name = "core-bg")
-  # a 0%-width bar gets no gradient colours, just the plain background colour
-  fill <- cfg$grobs[ind][[1]][["gp"]][["fill"]]
-  expect_true(all(fill == "#FFFFFF"))
+  # one rect grob is added per cell, including the one that rescales to 0%
+  expect_equal(nrow(cfg$layout), nrow(cfg_before$layout) + 3)
 })
 
 test_that("rule_fill_bar na.value does not crash when only some columns are targeted", {
@@ -144,15 +147,18 @@ test_that("rule_fill_bar lockcells prevents further CSS rules from overwriting n
 })
 
 test_that("rule_fill_bar lockcells prevents further gtable rules from applying", {
-  cfg <- data.frame(a = c(1, 3, 5)) %>%
+  # each non-NA cell gets its own rect grob added on top of "core-bg" (which
+  # is left untouched), so a locked-out second rule must add zero new grobs
+  cfg_rule1_only <- data.frame(a = c(1, 3, 5)) %>%
+    condformat() %>%
+    rule_fill_bar(a, background = "red", lockcells = TRUE) %>%
+    condformat2grob(draw = FALSE)
+  cfg_both <- data.frame(a = c(1, 3, 5)) %>%
     condformat() %>%
     rule_fill_bar(a, background = "red", lockcells = TRUE) %>%
     rule_fill_bar(a, background = "blue") %>%
     condformat2grob(draw = FALSE)
-  # row 1 (a=1) rescales to exactly 0%, so its fill is background colour only
-  ind <- find_cell(cfg, 2, 2, name = "core-bg")
-  fill <- cfg$grobs[ind][[1]][["gp"]][["fill"]]
-  expect_true(all(fill == "#FF0000"))
+  expect_equal(nrow(cfg_both$layout), nrow(cfg_rule1_only$layout))
 })
 
 test_that("rule_fill_bar lockcells prevents further gtable rules from overwriting na.value", {

--- a/tests/testthat/test-rule-fill-bar.R
+++ b/tests/testthat/test-rule-fill-bar.R
@@ -132,3 +132,35 @@ test_that("rule_fill_bar na.value does not crash when only some columns are targ
   expect_equal(css_fields$`background-color`[2, 1], "#BEBEBE")
   expect_true(is.na(css_fields$`background-color`[1, 2]))
 })
+
+test_that("rule_fill_bar lockcells prevents further CSS rules from overwriting na.value", {
+  y <- data.frame(a = c(1, NA, 5)) %>%
+    condformat() %>%
+    rule_fill_bar(a, na.value = "red", lockcells = TRUE) %>%
+    rule_fill_bar(a, na.value = "blue")
+  xv_cf <- get_xview_and_cf_fields(y)
+  css_fields <- render_cf_fields_to_css_fields(xv_cf$cf_fields, xv_cf$xview)
+  expect_equal(css_fields$`background-color`[2, 1], "#FF0000")
+})
+
+test_that("rule_fill_bar lockcells prevents further gtable rules from applying", {
+  cfg <- data.frame(a = c(1, 3, 5)) %>%
+    condformat() %>%
+    rule_fill_bar(a, background = "red", lockcells = TRUE) %>%
+    rule_fill_bar(a, background = "blue") %>%
+    condformat2grob(draw = FALSE)
+  # row 1 (a=1) rescales to exactly 0%, so its fill is background colour only
+  ind <- find_cell(cfg, 2, 2, name = "core-bg")
+  fill <- cfg$grobs[ind][[1]][["gp"]][["fill"]]
+  expect_true(all(fill == "#FF0000"))
+})
+
+test_that("rule_fill_bar lockcells prevents further gtable rules from overwriting na.value", {
+  cfg <- data.frame(a = c(1, NA, 5)) %>%
+    condformat() %>%
+    rule_fill_bar(a, na.value = "red", lockcells = TRUE) %>%
+    rule_fill_bar(a, na.value = "blue") %>%
+    condformat2grob(draw = FALSE)
+  ind <- find_cell(cfg, 3, 2, name = "core-bg")
+  expect_equal(cfg$grobs[ind][[1]][["gp"]][["fill"]], "#FF0000")
+})

--- a/tests/testthat/test-rule-fill-bar.R
+++ b/tests/testthat/test-rule-fill-bar.R
@@ -14,9 +14,8 @@ test_that("rule_fill_bar computes border, background-color and background-image"
   xv_cf <- get_xview_and_cf_fields(x)
   css_fields <- render_cf_fields_to_css_fields(xv_cf$cf_fields, xv_cf$xview)
 
-  # NA cells get no border/gradient/background-color (na.value is only used
-  # for the gtable fill, not for the CSS/HTML background-color)
-  expect_true(is.na(css_fields$`background-color`[2, 1]))
+  # NA cells get na.value as background-color, and no border/gradient
+  expect_equal(css_fields$`background-color`[2, 1], "#BEBEBE")
   expect_true(is.na(css_fields$border[2, 1]))
   expect_true(is.na(css_fields$`background-image`[2, 1]))
 
@@ -35,7 +34,7 @@ test_that("rule_fill_bar respects custom low/high/background/na.value colours", 
   xv_cf <- get_xview_and_cf_fields(x)
   css_fields <- render_cf_fields_to_css_fields(xv_cf$cf_fields, xv_cf$xview)
 
-  expect_true(is.na(css_fields$`background-color`[2, 1]))
+  expect_equal(css_fields$`background-color`[2, 1], "#FFFF00")
   expect_equal(css_fields$`background-color`[1, 1], "#000000")
   expect_equal(
     css_fields$`background-image`[1, 1],
@@ -111,4 +110,25 @@ test_that("rule_fill_bar gtable renders a gradient bar and a plain fill for NA c
 
   ind_na <- find_cell(cfg, 3, 2, name = "core-bg")
   expect_equal(cfg$grobs[ind_na][[1]][["gp"]][["fill"]], "#BEBEBE")
+})
+
+test_that("rule_fill_bar gtable does not crash when a value rescales to exactly 0%", {
+  cfg <- data.frame(a = c(1, 3, 5)) %>%
+    condformat() %>%
+    rule_fill_bar(a) %>%
+    condformat2grob(draw = FALSE)
+  ind <- find_cell(cfg, 2, 2, name = "core-bg")
+  # a 0%-width bar gets no gradient colours, just the plain background colour
+  fill <- cfg$grobs[ind][[1]][["gp"]][["fill"]]
+  expect_true(all(fill == "#FFFFFF"))
+})
+
+test_that("rule_fill_bar na.value does not crash when only some columns are targeted", {
+  x <- data.frame(a = c(1, NA, 5), b = c(10, 20, 30)) %>%
+    condformat() %>%
+    rule_fill_bar(a)
+  xv_cf <- get_xview_and_cf_fields(x)
+  css_fields <- render_cf_fields_to_css_fields(xv_cf$cf_fields, xv_cf$xview)
+  expect_equal(css_fields$`background-color`[2, 1], "#BEBEBE")
+  expect_true(is.na(css_fields$`background-color`[1, 2]))
 })


### PR DESCRIPTION
## Summary

This stacks on #36 (the `rule_fill_bar.R` coverage PR) since it fixes exactly the behavior those new tests exercise — merge #36 first, then this one.

Four related, pre-existing bugs in `R/rule_fill_bar.R`, all surfaced by that coverage work, none caused by any of the earlier PRs in this series:

1. **Dead code**: `cf_field_to_css.cf_field_rule_bar_gradient`'s `mask` is `unlocked & !is.na(bar_width_percent)` — it already excludes NA cells. `background_color[mask & pbar_is_na] <- <na.value colour>` tries to reach exactly the cells `mask` excludes, so that expression is the all-`FALSE` matrix for any input. `na.value` was silently never applied to `background-color` in HTML output, despite being documented. Fixed by gating that one assignment on `unlocked` alone (`pbar_is_na` holds raw `NA`, not `FALSE`, for untargeted columns, so that's cleaned up first — putting a raw `NA` inside an assignment's logical index makes R error with "NAs are not allowed in subscripted assignments").
2. **Crash**: `cf_field_to_gtable.cf_field_rule_bar_gradient` calls `colorRampPalette(c(low, high), space = "Lab")(fill_to)`. When a value rescales to exactly the minimum (0% bar width), `fill_to = 0` and this call errors (can't request zero colours). Fixed by skipping the ramp call for `fill_to == 0` and using just the background colour, which is the correct rendering for a 0%-width bar.
3. **`lockcells` gap (CSS)**: `unlocked[mask] <- FALSE` only ever locked non-NA cells (same reason as #1 — `mask` excludes them), so an NA cell painted with `na.value` was never actually protected from a later rule.
4. **`lockcells` gap (gtable) — broader than #3**: the gtable paint loop never checked `unlocked`/`mask` at all before drawing, for *either* the NA-fill or gradient-rect branch. `mask` was computed but only used to update outgoing lock state, never to gate this rule's own painting. Result: `lockcells = TRUE` didn't protect *any* cell — NA or not — from a later `rule_fill_bar()` call in grob/gtable output.

## Test plan
- [x] Flipped the two `na.value`/`background-color` assertions in `test-rule-fill-bar.R` (added in #36) back to expect the real colour now that it works
- [x] Added regression tests for the 0%-width crash and the multi-column NA-index crash
- [x] Added regression tests for all four lockcells combinations (CSS/gtable × NA/non-NA cells)
- [ ] CI runs green
