### PR TITLE
Expand test coverage for render_gtable.R

### DIFF
--- a/tests/testthat/test-render-gtable.R
+++ b/tests/testthat/test-render-gtable.R
@@ -6,3 +6,42 @@ test_that("basic condformat works", {
   expect_equal(length(cfg), 216)
   vdiffr::expect_doppelganger(title = "Basic condformat image", cfg)
 })
+
+test_that("condformat2grob omits the rowname offset when rows = NULL", {
+  cfg <- data.frame(a = "Dog") %>%
+    condformat() %>%
+    theme_grob(rows = NULL) %>%
+    rule_fill_discrete("a", colours = c("Dog" = "#FF0000")) %>%
+    condformat2grob(draw = FALSE)
+  ind <- find_cell(cfg, 2, 1, name = "core-bg")
+  expect_equal(cfg$grobs[ind][[1]][["gp"]][["fill"]], "#FF0000")
+})
+
+test_that("condformat2grob combines multiple rules on the same cell", {
+  cfg <- data.frame(a = "Dog") %>%
+    condformat() %>%
+    rule_fill_discrete("a", colours = c("Dog" = "#FF0000")) %>%
+    rule_text_bold("a", expression = TRUE) %>%
+    condformat2grob(draw = FALSE)
+  ind_bg <- find_cell(cfg, 2, 2, name = "core-bg")
+  ind_fg <- find_cell(cfg, 2, 2, name = "core-fg")
+  expect_equal(cfg$grobs[ind_bg][[1]][["gp"]][["fill"]], "#FF0000")
+  expect_equal(cfg$grobs[ind_fg][[1]][["gp"]][["fontface"]], "bold")
+})
+
+test_that("condformat2grob draws without error when draw = TRUE", {
+  grDevices::pdf(file = tempfile(fileext = ".pdf"))
+  on.exit(grDevices::dev.off(), add = TRUE)
+  result <- condformat2grob(condformat(head(iris)))
+  expect_s3_class(result, "gtable")
+})
+
+test_that("cf_field_to_gtable warns for rules with no gtable method", {
+  expect_warning(
+    condformat2grob(
+      data.frame(a = "Dog") %>%
+        condformat() %>%
+        rule_css("a", expression = "red", css_field = "color"),
+      draw = FALSE),
+    "not supported by condformat in this output format")
+})

--- a/tests/testthat/test-render-gtable.R
+++ b/tests/testthat/test-render-gtable.R
@@ -21,12 +21,12 @@ test_that("condformat2grob combines multiple rules on the same cell", {
   cfg <- data.frame(a = "Dog") %>%
     condformat() %>%
     rule_fill_discrete("a", colours = c("Dog" = "#FF0000")) %>%
-    rule_text_bold("a", expression = TRUE) %>%
+    rule_text_color("a", expression = "blue") %>%
     condformat2grob(draw = FALSE)
   ind_bg <- find_cell(cfg, 2, 2, name = "core-bg")
   ind_fg <- find_cell(cfg, 2, 2, name = "core-fg")
   expect_equal(cfg$grobs[ind_bg][[1]][["gp"]][["fill"]], "#FF0000")
-  expect_equal(cfg$grobs[ind_fg][[1]][["gp"]][["fontface"]], "bold")
+  expect_equal(unname(cfg$grobs[ind_fg][[1]][["gp"]][["col"]]), "blue")
 })
 
 test_that("condformat2grob draws without error when draw = TRUE", {


### PR DESCRIPTION
## Summary
- `render_gtable.R` (`condformat2grob`, `render_cf_fields_to_grob`, the `cf_field_to_gtable` generic/default, `find_cell`) had only an 8-line test gated on `vdiffr` being installed.
- Added coverage for: the `has_rownames` offset when `theme_grob(rows = NULL)` is used, multiple rules being threaded through the same gtable object without clobbering each other (`render_cf_fields_to_grob`'s loop), the `draw = TRUE` code path, and the default/fallback warning for rules with no `cf_field_to_gtable` method (`rule_css`, which only supports HTML).
- No production code changes.

## Test plan
- [ ] CI runs green


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_