### PR TITLE
Add test coverage for theme_grob.R and theme_caption.R

### DIFF
--- a/tests/testthat/test-theme-caption.R
+++ b/tests/testthat/test-theme-caption.R
@@ -1,0 +1,25 @@
+test_that("theme_caption works with HTML output", {
+  out <- data.frame(a = 1) %>%
+    condformat() %>%
+    theme_caption("My Caption") %>%
+    condformat2html()
+  expect_match(out, "My Caption", fixed = TRUE)
+})
+
+test_that("theme_caption works with LaTeX output", {
+  out <- data.frame(a = 1) %>%
+    condformat() %>%
+    theme_caption("My Caption") %>%
+    condformat2latex()
+  expect_match(out, "My Caption", fixed = TRUE)
+})
+
+test_that("theme_caption's last chained call wins", {
+  out <- data.frame(a = 1) %>%
+    condformat() %>%
+    theme_caption("First") %>%
+    theme_caption("Second") %>%
+    condformat2html()
+  expect_false(grepl("First", out, fixed = TRUE))
+  expect_match(out, "Second", fixed = TRUE)
+})

--- a/tests/testthat/test-theme-grob.R
+++ b/tests/testthat/test-theme-grob.R
@@ -1,0 +1,18 @@
+test_that("theme_grob stores NULL values instead of dropping them", {
+  x <- condformat(head(iris)) %>% theme_grob(rows = NULL)
+  themes <- attr(x, "condformat")[["themes"]]
+  finaltheme <- render_theme_condformat_tbl(themes, head(iris))
+  expect_true("rows" %in% names(finaltheme[["tableGrobArgs"]]))
+  expect_null(finaltheme[["tableGrobArgs"]][["rows"]])
+})
+
+test_that("theme_grob args accumulate across chained calls", {
+  x <- condformat(head(iris)) %>%
+    theme_grob(rows = NULL) %>%
+    theme_grob(cols = 1:2)
+  themes <- attr(x, "condformat")[["themes"]]
+  finaltheme <- render_theme_condformat_tbl(themes, head(iris))
+  expect_true("rows" %in% names(finaltheme[["tableGrobArgs"]]))
+  expect_null(finaltheme[["tableGrobArgs"]][["rows"]])
+  expect_equal(finaltheme[["tableGrobArgs"]][["cols"]], 1:2)
+})


### PR DESCRIPTION
## Summary
- Neither `theme_grob.R` nor `theme_caption.R` had a dedicated test file.
- `theme_grob`: added coverage for `NULL` values (e.g. `rows = NULL`) being stored rather than dropped, and for args accumulating correctly across chained calls. `theme_grob` already used the correct `names(finaltheme)` check (unlike `theme_htmlTable` before #35's fix), so these are regression guards against the same class of bug recurring here.
- `theme_caption`: added coverage for LaTeX output (its documented advantage over `theme_htmlTable(caption = ...)`, which is HTML-only) and the last-caller-wins semantics when chaining multiple `theme_caption()` calls.
- No production code changes.

## Test plan
- [ ] CI runs green


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_