### PR TITLE
Expand test coverage for render_xlsx.R

### DIFF
--- a/tests/testthat/test-render-excel.R
+++ b/tests/testthat/test-render-excel.R
@@ -109,7 +109,7 @@ test_that("condformat2excel applies and caches fill/bold/color styles across rep
     condformat() %>%
     rule_fill_discrete("a", colours = c("Dog" = "#FF0000", "Cat" = "#00FF00")) %>%
     rule_text_bold("a", expression = a == "Dog") %>%
-    rule_text_color("a", expression = "blue")
+    rule_text_color("a", expression = ifelse(a == "Dog", "blue", "purple"))
   condformat2excel(x, filename = filename)
   expect_true(file.exists(filename))
   workbook <- openxlsx::loadWorkbook(filename)

--- a/tests/testthat/test-render-excel.R
+++ b/tests/testthat/test-render-excel.R
@@ -72,3 +72,47 @@ test_that("condformat2excel warns if unsupported rule is used", {
     regexp = "condformat2excel does not support the following rules"
   )
 })
+
+test_that("condformat2excel appends .xlsx to the filename if missing", {
+  base <- tempfile()
+  filename <- paste0(base, ".xlsx")
+  on.exit(unlink(filename))
+  condformat2excel(condformat(head(iris)), filename = base)
+  expect_true(file.exists(filename))
+})
+
+test_that("condformat2excel errors if the file exists and no overwrite is allowed", {
+  filename <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(filename))
+  condformat2excel(condformat(head(iris)), filename = filename)
+  expect_error(
+    condformat2excel(condformat(head(iris)), filename = filename,
+                     overwrite_wb = FALSE, overwrite_sheet = FALSE),
+    "already exists"
+  )
+})
+
+test_that("condformat2excel overwrite_wb replaces the whole workbook", {
+  filename <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(filename))
+  condformat2excel(condformat(head(iris)), filename = filename, sheet_name = "first")
+  condformat2excel(condformat(head(iris)), filename = filename, sheet_name = "second",
+                   overwrite_wb = TRUE)
+  workbook <- openxlsx::loadWorkbook(filename)
+  expect_equal(names(workbook), "second")
+})
+
+test_that("condformat2excel applies and caches fill/bold/color styles across repeated rows", {
+  filename <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(filename))
+  x <- data.frame(a = rep(c("Dog", "Cat"), 3)) %>%
+    condformat() %>%
+    rule_fill_discrete("a", colours = c("Dog" = "#FF0000", "Cat" = "#00FF00")) %>%
+    rule_text_bold("a", expression = a == "Dog") %>%
+    rule_text_color("a", expression = "blue")
+  condformat2excel(x, filename = filename)
+  expect_true(file.exists(filename))
+  workbook <- openxlsx::loadWorkbook(filename)
+  expect_true(length(workbook$styleObjects) > 0)
+  expect_equal(nrow(openxlsx::read.xlsx(filename, 1)), 6)
+})


### PR DESCRIPTION
## Summary
- Every existing test in `test-render-excel.R` either wrote a plain table with no rules, or checked the unsupported-rule warning — none of them ever applied a supported style rule (`rule_fill_discrete`/`rule_text_bold`/`rule_text_color`), so the style-building and style-caching logic (`condformat2excelsheet`'s `created_styles` hash) was entirely unexercised.
- Added coverage for: the `.xlsx` extension auto-append, the error path when a file exists and neither overwrite flag is set, `overwrite_wb` replacing the whole workbook (vs. `overwrite_sheet` touching just one sheet), and applying fill/bold/color rules across repeated rows so both the "create a new style" and "reuse a cached style" branches run.
- No production code changes.

## Test plan
- [ ] CI runs green


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_