### PR TITLE
Recycle scalar expressions in rule_text_bold/text_color/css

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,11 @@
   later CSS/HTML rules, and not protecting any cell (NA or not) from later
   grob/gtable rules: the grob/gtable renderer painted every targeted cell
   unconditionally and never checked incoming lock state at all.
+* Fix `rule_text_bold()`, `rule_text_color()` and `rule_css()` erroring when
+  `expression` evaluates to a single (scalar) value on a table with more than
+  one row, unlike `rule_fill_discrete()`, `rule_fill_gradient()`,
+  `rule_fill_gradient2()` and `rule_fill_bar()`, which already recycled such
+  values to every row.
 
 # condformat 0.10.1
 

--- a/R/rule_css.R
+++ b/R/rule_css.R
@@ -47,6 +47,7 @@ rule_to_cf_field.rule_css <- function(rule, xfiltered, xview, ...) {
     rule[["expression"]] <- rlang::sym(names(columns)[1])
   }
   css_values <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
+  css_values <- rep(css_values, length.out = nrow(xfiltered))
   stopifnot(identical(length(css_values), nrow(xview)))
   # Recycle css values to fit all the columns:
   css_values_mat <- matrix(NA,

--- a/R/rule_text_bold.R
+++ b/R/rule_text_bold.R
@@ -43,6 +43,7 @@ rule_to_cf_field.rule_text_bold <- function(rule, xfiltered, xview, ...) {
     rule[["expression"]] <- rlang::sym(names(columns)[1])
   }
   bold_or_not <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
+  bold_or_not <- rep(bold_or_not, length.out = nrow(xfiltered))
   stopifnot(identical(length(bold_or_not), nrow(xview)))
   # Recycle css values to fit all the columns:
   bold_or_not_mat_l <- matrix(bold_or_not, nrow = nrow(xview),

--- a/R/rule_text_color.R
+++ b/R/rule_text_color.R
@@ -43,6 +43,7 @@ rule_to_cf_field.rule_text_color <- function(rule, xfiltered, xview, ...) {
     rule[["expression"]] <- rlang::sym(names(columns)[1])
   }
   colors <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
+  colors <- rep(colors, length.out = nrow(xfiltered))
   colors[is.na(colors)] <- rule[["na.value"]]
   stopifnot(identical(length(colors), nrow(xview)))
   # Recycle css values to fit all the columns:

--- a/tests/testthat/test-rule-css.R
+++ b/tests/testthat/test-rule-css.R
@@ -9,3 +9,10 @@ test_that("rule_css works", {
   expect_match(out, "red")
   expect_match(out, "darkgreen")
 })
+
+test_that("rule_css recycles a scalar expression to every row", {
+  out <- condformat(iris[1:5, ]) %>%
+    rule_css(Species, expression = "solid", css_field = "border-style") %>%
+    condformat2html()
+  expect_equal(lengths(regmatches(out, gregexpr("border-style: solid", out))), 5)
+})

--- a/tests/testthat/test-rule-text-bold.R
+++ b/tests/testthat/test-rule-text-bold.R
@@ -19,6 +19,13 @@ test_that("rule_text_bold works for LaTeX output", {
   expect_true(any(grepl(pattern = "\\textbf{potato}", x[[1]], fixed = TRUE)))
 })
 
+test_that("rule_text_bold recycles a scalar expression to every row", {
+  out <- condformat(iris[1:5, ]) %>%
+    rule_text_bold(Species, expression = TRUE) %>%
+    condformat2html()
+  expect_equal(lengths(regmatches(out, gregexpr("font-weight: bold", out))), 5)
+})
+
 test_that("rule_text_bold lockcells prevents further LaTeX rules from applying", {
   out <- condformat(data.frame(a = "potato")) %>%
     rule_text_bold("a", expression = TRUE, lockcells = TRUE) %>%

--- a/tests/testthat/test-rule-text-color.R
+++ b/tests/testthat/test-rule-text-color.R
@@ -10,6 +10,13 @@ test_that("rule_text_color works", {
   expect_false(grepl(pattern = "\\textcolor[RGB]{0,0,255}{versicolor}", out, fixed = TRUE))
 })
 
+test_that("rule_text_color recycles a scalar expression to every row", {
+  out <- condformat(iris[1:5, ]) %>%
+    rule_text_color(Species, expression = "red") %>%
+    condformat2html()
+  expect_equal(lengths(regmatches(out, gregexpr("color: red", out))), 5)
+})
+
 test_that("rule_text_color lockcells prevents further LaTeX rules from applying", {
   out <- condformat(data.frame(a = "potato")) %>%
     rule_text_color("a", expression = "red", lockcells = TRUE) %>%


### PR DESCRIPTION
## Summary

`rule_fill_bar()`, `rule_fill_discrete()`, `rule_fill_gradient()` and `rule_fill_gradient2()` all recycle their evaluated `expression` to `nrow(xfiltered)` via `rep(..., length.out = ...)` before checking its length, so a scalar expression (e.g. `expression = "red"`) applies to every row. `rule_text_bold()`, `rule_text_color()` and `rule_css()` were missing that `rep()` call and went straight to `stopifnot(identical(length(x), nrow(xview)))`, so the same natural usage failed with an unhelpful internal `stopifnot` error instead of working like the other four rules:

```r
# Works: rule_fill_discrete recycles "red" to all 5 rows
condformat(iris[1:5, ]) %>% rule_fill_discrete(Species, expression = "red")

# Broke before this fix:
condformat(iris[1:5, ]) %>% rule_text_color(Species, expression = "red")
#> Error: identical(length(colors), nrow(xview)) is not TRUE
```

Added the same recycling step to all three rules, in the same place it happens in the fill rules (right after `eval_tidy`, before any `na.value` substitution), plus a regression test per rule confirming a scalar expression now applies to every row.

## Test plan
- [x] Added a regression test per rule (`rule_text_bold`, `rule_text_color`, `rule_css`) asserting a scalar `expression` styles all 5 rows of a table
- [ ] CI runs green


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_