### PR TITLE
Add .col pronoun to all condformat rules (closes #19)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # condformat 0.10.1.9000
 
+## New features
+
+* Add a `.col` pronoun usable in the `expression` argument of `rule_fill_discrete()`,
+  `rule_fill_gradient()`, `rule_fill_gradient2()`, `rule_fill_bar()`, `rule_text_bold()`,
+  `rule_text_color()` and `rule_css()`. When `columns` selects more than one column,
+  `.col` is bound to each column's own values in turn, so a single rule call can
+  format several columns based on each one's own condition (closes #19):
+  `rule_fill_discrete(c(Sepal.Length, Sepal.Width), .col > 3)` is now equivalent to
+  chaining the rule once per column. `expression` now also defaults to `.col` when
+  omitted, replacing the previous behaviour of silently using only the first
+  selected column (with a warning) when no expression was given for a multi-column
+  selection.
+
 ## Fixes
 
 * Fix `lockcells = TRUE` being ignored (or worse, unlocking cells) for LaTeX

--- a/R/rule_css.R
+++ b/R/rule_css.R
@@ -1,7 +1,10 @@
 #' Apply a CSS style property as a conditional formatting rule
 #' @family rule
 #' @inheritParams rule_fill_discrete
-#' @param expression This expression should evaluate to an array of the values
+#' @param expression This expression should evaluate to an array of the values.
+#'                   When `columns` selects more than one column, the expression is
+#'                   evaluated once per column, with the `.col` pronoun bound to that
+#'                   column's own values. If omitted, it defaults to `.col`.
 #'
 #' @param css_field CSS style property name (e.g. `"color"`)
 #' @param na.value CSS property value to be used in missing values (e.g. `"grey"`)
@@ -38,23 +41,19 @@ rule_to_cf_field.rule_css <- function(rule, xfiltered, xview, ...) {
     return(NULL)
   }
   if (rlang::quo_is_missing(rule[["expression"]])) {
-    if (length(columns) > 1) {
-      warning("rule_css applied to multiple columns, using column ",
-              names(columns)[1], " values as expression. In the future this behaviour will change,",
-              "please use a explicit expression instead.",
-              call. = FALSE)
-    }
-    rule[["expression"]] <- rlang::sym(names(columns)[1])
+    rule[["expression"]] <- rlang::sym(".col")
   }
-  css_values <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
-  css_values <- rep(css_values, length.out = nrow(xfiltered))
-  stopifnot(identical(length(css_values), nrow(xview)))
-  # Recycle css values to fit all the columns:
+  values_per_column <- eval_expression_per_column(rule[["expression"]], xfiltered, columns)
+
   css_values_mat <- matrix(NA,
                            nrow = nrow(xview), ncol = ncol(xview),
                            byrow = FALSE)
   colnames(css_values_mat) <- colnames(xview)
-  css_values_mat[, columns] <- css_values
+  for (col_name in names(columns)) {
+    css_values <- values_per_column[[col_name]]
+    stopifnot(identical(length(css_values), nrow(xview)))
+    css_values_mat[, col_name] <- css_values
+  }
   cf_field <- structure(list(css_key = rule[["css_field"]],
                              css_values = css_values_mat,
                              lock_cells = rule[["lockcells"]]),

--- a/R/rule_fill_bar.R
+++ b/R/rule_fill_bar.R
@@ -11,6 +11,10 @@
 #' @param expression an expression to be evaluated with the data.
 #'                   It should evaluate to a numeric vector,
 #'                   that will be used to determine the colour gradient level.
+#'                   When `columns` selects more than one column, the expression is
+#'                   evaluated once per column, with the `.col` pronoun bound to that
+#'                   column's own values (and `limits`, if not given, computed from
+#'                   that column alone). If omitted, it defaults to `.col`.
 #' @param low Colour for the beginning of the bar
 #' @param high Colour for the end of the bar
 #' @param background Background colour for the cell
@@ -58,43 +62,39 @@ rule_to_cf_field.rule_fill_bar <- function(rule, xfiltered, xview, ...) {
     return(NULL)
   }
   if (rlang::quo_is_missing(rule[["expression"]])) {
-    if (length(columns) > 1) {
-      warning("rule_fill_bar applied to multiple columns, using column ",
-              names(columns)[1], " values as expression. In the future this behaviour will change,",
-              " please use a explicit expression instead.",
-              call. = FALSE)
-    }
-    rule[["expression"]] <- rlang::sym(names(columns)[1])
+    rule[["expression"]] <- rlang::sym(".col")
   }
-  values_determining_color <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
-  values_determining_color <- rep(values_determining_color, length.out = nrow(xfiltered))
-
-  if (identical(rule[["limits"]], NA)) {
-    limits <- range(values_determining_color, na.rm = TRUE)
-  } else {
-    limits <- rule[["limits"]]
-    if (is.na(limits[1])) {
-      limits[1] <- min(values_determining_color, na.rm = TRUE)
-    }
-    if (is.na(limits[2])) {
-      limits[2] <- max(values_determining_color, na.rm = TRUE)
-    }
-  }
-
-  values_rescaled <- scales::rescale(x = values_determining_color, from = limits)
-  stopifnot(identical(length(values_rescaled), nrow(xview)))
+  values_per_column <- eval_expression_per_column(rule[["expression"]], xfiltered, columns)
 
   bar_width_percent <- matrix(NA,
                               nrow = nrow(xview), ncol = ncol(xview),
                               byrow = FALSE)
   colnames(bar_width_percent) <- colnames(xview)
-  bar_width_percent[, columns] <- values_rescaled
   pbar_is_na <- matrix(NA,
                        nrow = nrow(xview), ncol = ncol(xview),
                        byrow = FALSE)
   colnames(pbar_is_na) <- colnames(xview)
 
-  pbar_is_na[, columns] <- is.na(values_rescaled)
+  for (col_name in names(columns)) {
+    values_determining_color <- values_per_column[[col_name]]
+    if (identical(rule[["limits"]], NA)) {
+      limits <- range(values_determining_color, na.rm = TRUE)
+    } else {
+      limits <- rule[["limits"]]
+      if (is.na(limits[1])) {
+        limits[1] <- min(values_determining_color, na.rm = TRUE)
+      }
+      if (is.na(limits[2])) {
+        limits[2] <- max(values_determining_color, na.rm = TRUE)
+      }
+    }
+
+    values_rescaled <- scales::rescale(x = values_determining_color, from = limits)
+    stopifnot(identical(length(values_rescaled), nrow(xview)))
+
+    bar_width_percent[, col_name] <- values_rescaled
+    pbar_is_na[, col_name] <- is.na(values_rescaled)
+  }
 
   col_low <- grDevices::col2rgb(rule[["low"]])
   col_high <- grDevices::col2rgb(rule[["high"]])

--- a/R/rule_fill_discrete.R
+++ b/R/rule_fill_discrete.R
@@ -10,6 +10,10 @@
 #' @param expression an expression to be evaluated with the data.
 #'                   It should evaluate to a logical or an integer vector,
 #'                   that will be used to determine which cells are to be coloured.
+#'                   When `columns` selects more than one column, the expression is
+#'                   evaluated once per column, with the `.col` pronoun bound to that
+#'                   column's own values, so the same call can colour several columns
+#'                   based on each one's own condition. If omitted, it defaults to `.col`.
 #' @param colours a character vector with colours as values and the expression
 #'                possible results as names.
 #' @inheritParams scales::hue_pal
@@ -33,6 +37,14 @@
 #'  rule_fill_discrete(c(starts_with("Sepal"), starts_with("Petal")),
 #'                     expression = Sepal.Length > 4.6,
 #'                     colours=c("TRUE"="red"))
+#' \dontrun{
+#' print(cf)
+#' }
+#'
+#' # .col lets each selected column use its own values in the expression:
+#' cf <- condformat(iris[c(1:5, 70:75, 120:125), ]) %>%
+#'  rule_fill_discrete(c(Sepal.Length, Sepal.Width), .col > 3,
+#'                     colours = c("TRUE" = "red"))
 #' \dontrun{
 #' print(cf)
 #' }
@@ -67,40 +79,37 @@ rule_to_cf_field.rule_fill_discrete <- function(rule, xfiltered, xview, ...) {
     return(NULL)
   }
   if (rlang::quo_is_missing(rule[["expression"]])) {
-    if (length(columns) > 1) {
-      warning("rule_fill_discrete applied to multiple columns, using column ",
-              names(columns)[1], " values as expression. In the future this behaviour will change,",
-              "please use a explicit expression instead.",
-              call. = FALSE)
-    }
-    rule[["expression"]] <- rlang::sym(names(columns)[1])
+    rule[["expression"]] <- rlang::sym(".col")
   }
-  values_determining_color <- as.factor(rlang::eval_tidy(rule[["expression"]], data = xfiltered))
-  values_determining_color <- rep(values_determining_color, length.out = nrow(xfiltered))
+  values_per_column <- eval_expression_per_column(rule[["expression"]], xfiltered, columns)
 
-  colours_for_values <- NA
-  if (identical(rule[["colours"]], NA)) {
-    # colours not given: Create a palette
-    number_colours <- length(unique(values_determining_color))
-    col_scale <- scales::hue_pal(h = rule[["h"]], c = rule[["c"]], l = rule[["l"]],
-                                 h.start = rule[["h.start"]],
-                                 direction = rule[["direction"]])(number_colours)
-    colours_for_values <- col_scale[as.integer(values_determining_color)]
-  } else if (is.character(rule[["colours"]])) {
-    colours_for_values <- rule[["colours"]][match(values_determining_color, names(rule[["colours"]]))]
-  } else if (is.function(rule[["colours"]])) {
-    colours_for_values <- rule[["colours"]](values_determining_color)
-    if (is.factor(colours_for_values)) {
-      colours_for_values <- as.character(colours_for_values)
-    }
-  }
-  colours_for_values[is.na(colours_for_values)] <- rule[["na.value"]]
-  stopifnot(identical(length(colours_for_values), nrow(xview)))
   colours_for_values_mat <- matrix(NA,
                                    nrow = nrow(xview), ncol = ncol(xview),
                                    byrow = FALSE)
   colnames(colours_for_values_mat) <- colnames(xview)
-  colours_for_values_mat[, columns] <- colours_for_values
+  for (col_name in names(columns)) {
+    values_determining_color <- as.factor(values_per_column[[col_name]])
+
+    colours_for_values <- NA
+    if (identical(rule[["colours"]], NA)) {
+      # colours not given: Create a palette
+      number_colours <- length(unique(values_determining_color))
+      col_scale <- scales::hue_pal(h = rule[["h"]], c = rule[["c"]], l = rule[["l"]],
+                                   h.start = rule[["h.start"]],
+                                   direction = rule[["direction"]])(number_colours)
+      colours_for_values <- col_scale[as.integer(values_determining_color)]
+    } else if (is.character(rule[["colours"]])) {
+      colours_for_values <- rule[["colours"]][match(values_determining_color, names(rule[["colours"]]))]
+    } else if (is.function(rule[["colours"]])) {
+      colours_for_values <- rule[["colours"]](values_determining_color)
+      if (is.factor(colours_for_values)) {
+        colours_for_values <- as.character(colours_for_values)
+      }
+    }
+    colours_for_values[is.na(colours_for_values)] <- rule[["na.value"]]
+    stopifnot(identical(length(colours_for_values), nrow(xview)))
+    colours_for_values_mat[, col_name] <- colours_for_values
+  }
   cf_field <- structure(list(css_key = "background-color",
                              css_values = colours_for_values_mat,
                              lock_cells = rule[["lockcells"]]),

--- a/R/rule_fill_gradient.R
+++ b/R/rule_fill_gradient.R
@@ -11,6 +11,10 @@
 #' @param expression an expression to be evaluated with the data.
 #'                   It should evaluate to a numeric vector,
 #'                   that will be used to determine the colour gradient level.
+#'                   When `columns` selects more than one column, the expression is
+#'                   evaluated once per column, with the `.col` pronoun bound to that
+#'                   column's own values (and `limits`, if not given, computed from
+#'                   that column alone). If omitted, it defaults to `.col`.
 #' @inheritParams scales::seq_gradient_pal
 #' @param limits range of limits that the gradient should cover
 #' @param na.value fill color for missing values
@@ -64,33 +68,28 @@ rule_to_cf_field.rule_fill_gradient <- function(rule, xfiltered, xview, ...) {
     return(NULL)
   }
   if (rlang::quo_is_missing(rule[["expression"]])) {
-    if (length(columns) > 1) {
-      warning("rule_fill_gradient applied to multiple columns, using column ",
-              names(columns)[1], " values as expression. In the future this behaviour will change,",
-              " please use a explicit expression instead.",
-              call. = FALSE)
-    }
-    rule[["expression"]] <- rlang::sym(names(columns)[1])
+    rule[["expression"]] <- rlang::sym(".col")
   }
-  values_determining_color <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
-  values_determining_color <- rep(values_determining_color, length.out = nrow(xfiltered))
-
-  if (identical(rule[["limits"]], NA)) {
-    limits <- range(values_determining_color, na.rm = TRUE)
-  } else {
-    limits <- rule[["limits"]]
-  }
+  values_per_column <- eval_expression_per_column(rule[["expression"]], xfiltered, columns)
 
   col_scale <- scales::seq_gradient_pal(low = rule[["low"]], high = rule[["high"]])
 
-  values_rescaled <- scales::rescale(x = values_determining_color, from = limits)
-  colours_for_values <- col_scale(values_rescaled)
-  stopifnot(identical(length(colours_for_values), nrow(xview)))
   colours_for_values_mat <- matrix(NA,
                                    nrow = nrow(xview), ncol = ncol(xview),
                                    byrow = FALSE)
   colnames(colours_for_values_mat) <- colnames(xview)
-  colours_for_values_mat[, columns] <- colours_for_values
+  for (col_name in names(columns)) {
+    values_determining_color <- values_per_column[[col_name]]
+    if (identical(rule[["limits"]], NA)) {
+      limits <- range(values_determining_color, na.rm = TRUE)
+    } else {
+      limits <- rule[["limits"]]
+    }
+    values_rescaled <- scales::rescale(x = values_determining_color, from = limits)
+    colours_for_values <- col_scale(values_rescaled)
+    stopifnot(identical(length(colours_for_values), nrow(xview)))
+    colours_for_values_mat[, col_name] <- colours_for_values
+  }
   cf_field <- structure(list(css_key = "background-color",
                              css_values = colours_for_values_mat,
                              lock_cells = rule[["lockcells"]]),

--- a/R/rule_fill_gradient2.R
+++ b/R/rule_fill_gradient2.R
@@ -11,6 +11,10 @@
 #' @param expression an expression to be evaluated with the data.
 #'                   It should evaluate to a logical or an integer vector,
 #'                   that will be used to determine which cells are to be colored.
+#'                   When `columns` selects more than one column, the expression is
+#'                   evaluated once per column, with the `.col` pronoun bound to that
+#'                   column's own values (and `limits`/`midpoint`, if not given,
+#'                   computed from that column alone). If omitted, it defaults to `.col`.
 #' @inheritParams scales::div_gradient_pal
 #' @param midpoint the value used for the middle color (the median by default)
 #' @param limits range of limits that the gradient should cover
@@ -68,42 +72,37 @@ rule_to_cf_field.rule_fill_gradient2 <- function(rule, xfiltered, xview, ...) {
     return(NULL)
   }
   if (rlang::quo_is_missing(rule[["expression"]])) {
-    if (length(columns) > 1) {
-      warning("rule_fill_gradient2 applied to multiple columns, using column ",
-              names(columns)[1], " values as expression. In the future this behaviour will change,",
-              " please use a explicit expression instead.",
-              call. = FALSE)
-    }
-    rule[["expression"]] <- rlang::sym(names(columns)[1])
+    rule[["expression"]] <- rlang::sym(".col")
   }
-  values_determining_color <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
-  values_determining_color <- rep(values_determining_color, length.out = nrow(xfiltered))
-
-  if (identical(rule[["limits"]], NA)) {
-    limits <- range(values_determining_color, na.rm = TRUE)
-  } else {
-    limits <- rule[["limits"]]
-  }
-
-  if (is.na(rule[["midpoint"]])) {
-    midpoint <- stats::median(values_determining_color, na.rm = TRUE)
-  } else {
-    midpoint <- rule[["midpoint"]]
-  }
+  values_per_column <- eval_expression_per_column(rule[["expression"]], xfiltered, columns)
 
   col_scale <- scales::div_gradient_pal(low = rule[["low"]], mid = rule[["mid"]],
                                         high = rule[["high"]])
 
-  values_rescaled <- scales::rescale_mid(x = values_determining_color,
-                                         from = limits, mid = midpoint)
-
-  colors_for_values <- col_scale(values_rescaled)
-  stopifnot(identical(length(colors_for_values), nrow(xview)))
   colours_for_values_mat <- matrix(NA,
                                    nrow = nrow(xview), ncol = ncol(xview),
                                    byrow = FALSE)
   colnames(colours_for_values_mat) <- colnames(xview)
-  colours_for_values_mat[, columns] <- colors_for_values
+  for (col_name in names(columns)) {
+    values_determining_color <- values_per_column[[col_name]]
+    if (identical(rule[["limits"]], NA)) {
+      limits <- range(values_determining_color, na.rm = TRUE)
+    } else {
+      limits <- rule[["limits"]]
+    }
+
+    if (is.na(rule[["midpoint"]])) {
+      midpoint <- stats::median(values_determining_color, na.rm = TRUE)
+    } else {
+      midpoint <- rule[["midpoint"]]
+    }
+
+    values_rescaled <- scales::rescale_mid(x = values_determining_color,
+                                           from = limits, mid = midpoint)
+    colors_for_values <- col_scale(values_rescaled)
+    stopifnot(identical(length(colors_for_values), nrow(xview)))
+    colours_for_values_mat[, col_name] <- colors_for_values
+  }
   cf_field <- structure(list(css_key = "background-color",
                              css_values = colours_for_values_mat,
                              lock_cells = rule[["lockcells"]]),

--- a/R/rule_helper.R
+++ b/R/rule_helper.R
@@ -4,3 +4,27 @@ add_rule_to_condformat <- function(x, rule) {
   attr(x, "condformat") <- condformatopts
   x
 }
+
+# Evaluates `expr` once per column in `columns`, with the `.col` pronoun bound
+# in the data mask to that column's own values from `xfiltered`. This lets a
+# rule applied to several columns at once use an expression relative to each
+# column (e.g. `.col > 3`), instead of a single expression whose result is
+# broadcast identically to every selected column.
+#
+# @param expr A quosure or symbol to evaluate (typically `rule[["expression"]]`)
+# @param xfiltered The data frame the expression is evaluated against
+# @param columns A named integer vector of selected columns, as returned by
+#                [tidyselect::eval_select()]
+# @return A named list (one element per column in `columns`), each recycled
+#         to `nrow(xfiltered)`
+eval_expression_per_column <- function(expr, xfiltered, columns) {
+  col_names <- names(columns)
+  base_mask <- as.list(xfiltered)
+  values <- lapply(col_names, function(col_name) {
+    mask <- c(base_mask, list(.col = xfiltered[[col_name]]))
+    value <- rlang::eval_tidy(expr, data = mask)
+    rep(value, length.out = nrow(xfiltered))
+  })
+  names(values) <- col_names
+  values
+}

--- a/R/rule_text_bold.R
+++ b/R/rule_text_bold.R
@@ -2,6 +2,9 @@
 #' @family rule
 #' @inheritParams rule_fill_discrete
 #' @param expression Condition that evaluates to `TRUE` for the rows where bold text should be applied.
+#'                   When `columns` selects more than one column, the expression is
+#'                   evaluated once per column, with the `.col` pronoun bound to that
+#'                   column's own values. If omitted, it defaults to `.col`.
 #'
 #' @param na.bold If `TRUE`, make missing values bold.
 #' @examples
@@ -34,26 +37,19 @@ rule_to_cf_field.rule_text_bold <- function(rule, xfiltered, xview, ...) {
     return(NULL)
   }
   if (rlang::quo_is_missing(rule[["expression"]])) {
-    if (length(columns) > 1) {
-      warning("rule_text_bold applied to multiple columns, using column ",
-              names(columns)[1], " values as expression. In the future this behaviour will change,",
-              "please use a explicit expression instead.",
-              call. = FALSE)
-    }
-    rule[["expression"]] <- rlang::sym(names(columns)[1])
+    rule[["expression"]] <- rlang::sym(".col")
   }
-  bold_or_not <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
-  bold_or_not <- rep(bold_or_not, length.out = nrow(xfiltered))
-  stopifnot(identical(length(bold_or_not), nrow(xview)))
-  # Recycle css values to fit all the columns:
-  bold_or_not_mat_l <- matrix(bold_or_not, nrow = nrow(xview),
-                              ncol = ncol(xview), byrow = FALSE)
+  values_per_column <- eval_expression_per_column(rule[["expression"]], xfiltered, columns)
 
   bold_or_not_mat <- matrix(NA, nrow = nrow(xview), ncol = ncol(xview))
   colnames(bold_or_not_mat) <- colnames(xview)
-  bold_or_not_mat[bold_or_not, columns] <- "bold"
-  bold_or_not_mat[!bold_or_not, columns] <- "normal"
-  bold_or_not_mat[is.na(bold_or_not), columns] <- rule[["na.value"]]
+  for (col_name in names(columns)) {
+    bold_or_not <- values_per_column[[col_name]]
+    stopifnot(identical(length(bold_or_not), nrow(xview)))
+    col_values <- ifelse(bold_or_not, "bold", "normal")
+    col_values[is.na(bold_or_not)] <- rule[["na.value"]]
+    bold_or_not_mat[, col_name] <- col_values
+  }
 
   cf_field <- structure(list(css_key = "font-weight",
                              css_values = bold_or_not_mat,

--- a/R/rule_text_color.R
+++ b/R/rule_text_color.R
@@ -1,7 +1,10 @@
 #' Give a color to the text according to some expression
 #' @family rule
 #' @inheritParams rule_fill_discrete
-#' @param expression Condition that evaluates to color names for the rows where text should be colored
+#' @param expression Condition that evaluates to color names for the rows where text should be colored.
+#'                   When `columns` selects more than one column, the expression is
+#'                   evaluated once per column, with the `.col` pronoun bound to that
+#'                   column's own values. If omitted, it defaults to `.col`.
 #'
 #' @param na.color Color for missing values
 #' @examples
@@ -34,23 +37,19 @@ rule_to_cf_field.rule_text_color <- function(rule, xfiltered, xview, ...) {
     return(NULL)
   }
   if (rlang::quo_is_missing(rule[["expression"]])) {
-    if (length(columns) > 1) {
-      warning("rule_text_color applied to multiple columns, using column ",
-              names(columns)[1], " values as expression. In the future this behaviour will change,",
-              "please use a explicit expression instead.",
-              call. = FALSE)
-    }
-    rule[["expression"]] <- rlang::sym(names(columns)[1])
+    rule[["expression"]] <- rlang::sym(".col")
   }
-  colors <- rlang::eval_tidy(rule[["expression"]], data = xfiltered)
-  colors <- rep(colors, length.out = nrow(xfiltered))
-  colors[is.na(colors)] <- rule[["na.value"]]
-  stopifnot(identical(length(colors), nrow(xview)))
-  # Recycle css values to fit all the columns:
+  values_per_column <- eval_expression_per_column(rule[["expression"]], xfiltered, columns)
+
   colors_mat <- matrix(NA, nrow = nrow(xview),
                        ncol = ncol(xview))
   colnames(colors_mat) <- colnames(xview)
-  colors_mat[, columns] <- colors
+  for (col_name in names(columns)) {
+    colors <- values_per_column[[col_name]]
+    colors[is.na(colors)] <- rule[["na.value"]]
+    stopifnot(identical(length(colors), nrow(xview)))
+    colors_mat[, col_name] <- colors
+  }
   cf_field <- structure(list(css_key = "color",
                              css_values = colors_mat,
                              lock_cells = rule[["lockcells"]]),

--- a/man/rule_css.Rd
+++ b/man/rule_css.Rd
@@ -12,7 +12,10 @@ rule_css(x, columns, expression, css_field, na.value = "", lockcells = FALSE)
 \item{columns}{A character vector with column names to be coloured. Optionally
 \code{\link[tidyselect:language]{tidyselect::language()}} can be used.}
 
-\item{expression}{This expression should evaluate to an array of the values}
+\item{expression}{This expression should evaluate to an array of the values.
+When \code{columns} selects more than one column, the expression is
+evaluated once per column, with the \code{.col} pronoun bound to that
+column's own values. If omitted, it defaults to \code{.col}.}
 
 \item{css_field}{CSS style property name (e.g. \code{"color"})}
 

--- a/man/rule_fill_bar.Rd
+++ b/man/rule_fill_bar.Rd
@@ -24,7 +24,11 @@ rule_fill_bar(
 
 \item{expression}{an expression to be evaluated with the data.
 It should evaluate to a numeric vector,
-that will be used to determine the colour gradient level.}
+that will be used to determine the colour gradient level.
+When \code{columns} selects more than one column, the expression is
+evaluated once per column, with the \code{.col} pronoun bound to that
+column's own values (and \code{limits}, if not given, computed from
+that column alone). If omitted, it defaults to \code{.col}.}
 
 \item{low}{Colour for the beginning of the bar}
 

--- a/man/rule_fill_discrete.Rd
+++ b/man/rule_fill_discrete.Rd
@@ -26,7 +26,11 @@ rule_fill_discrete(
 
 \item{expression}{an expression to be evaluated with the data.
 It should evaluate to a logical or an integer vector,
-that will be used to determine which cells are to be coloured.}
+that will be used to determine which cells are to be coloured.
+When \code{columns} selects more than one column, the expression is
+evaluated once per column, with the \code{.col} pronoun bound to that
+column's own values, so the same call can colour several columns
+based on each one's own condition. If omitted, it defaults to \code{.col}.}
 
 \item{colours}{a character vector with colours as values and the expression
 possible results as names.}
@@ -70,6 +74,14 @@ cf <- condformat(iris[c(1:5, 70:75, 120:125), ]) \%>\%
  rule_fill_discrete(c(starts_with("Sepal"), starts_with("Petal")),
                     expression = Sepal.Length > 4.6,
                     colours=c("TRUE"="red"))
+\dontrun{
+print(cf)
+}
+
+# .col lets each selected column use its own values in the expression:
+cf <- condformat(iris[c(1:5, 70:75, 120:125), ]) \%>\%
+ rule_fill_discrete(c(Sepal.Length, Sepal.Width), .col > 3,
+                    colours = c("TRUE" = "red"))
 \dontrun{
 print(cf)
 }

--- a/man/rule_fill_gradient.Rd
+++ b/man/rule_fill_gradient.Rd
@@ -24,7 +24,11 @@ rule_fill_gradient(
 
 \item{expression}{an expression to be evaluated with the data.
 It should evaluate to a numeric vector,
-that will be used to determine the colour gradient level.}
+that will be used to determine the colour gradient level.
+When \code{columns} selects more than one column, the expression is
+evaluated once per column, with the \code{.col} pronoun bound to that
+column's own values (and \code{limits}, if not given, computed from
+that column alone). If omitted, it defaults to \code{.col}.}
 
 \item{low}{colour for low end of gradient.}
 

--- a/man/rule_fill_gradient2.Rd
+++ b/man/rule_fill_gradient2.Rd
@@ -26,7 +26,11 @@ rule_fill_gradient2(
 
 \item{expression}{an expression to be evaluated with the data.
 It should evaluate to a logical or an integer vector,
-that will be used to determine which cells are to be colored.}
+that will be used to determine which cells are to be colored.
+When \code{columns} selects more than one column, the expression is
+evaluated once per column, with the \code{.col} pronoun bound to that
+column's own values (and \code{limits}/\code{midpoint}, if not given,
+computed from that column alone). If omitted, it defaults to \code{.col}.}
 
 \item{low}{colour for low end of gradient.}
 

--- a/man/rule_text_bold.Rd
+++ b/man/rule_text_bold.Rd
@@ -12,7 +12,10 @@ rule_text_bold(x, columns, expression, na.bold = FALSE, lockcells = FALSE)
 \item{columns}{A character vector with column names to be coloured. Optionally
 \code{\link[tidyselect:language]{tidyselect::language()}} can be used.}
 
-\item{expression}{Condition that evaluates to \code{TRUE} for the rows where bold text should be applied.}
+\item{expression}{Condition that evaluates to \code{TRUE} for the rows where bold text should be applied.
+When \code{columns} selects more than one column, the expression is
+evaluated once per column, with the \code{.col} pronoun bound to that
+column's own values. If omitted, it defaults to \code{.col}.}
 
 \item{na.bold}{If \code{TRUE}, make missing values bold.}
 

--- a/man/rule_text_color.Rd
+++ b/man/rule_text_color.Rd
@@ -12,7 +12,10 @@ rule_text_color(x, columns, expression, na.color = "", lockcells = FALSE)
 \item{columns}{A character vector with column names to be coloured. Optionally
 \code{\link[tidyselect:language]{tidyselect::language()}} can be used.}
 
-\item{expression}{Condition that evaluates to color names for the rows where text should be colored}
+\item{expression}{Condition that evaluates to color names for the rows where text should be colored.
+When \code{columns} selects more than one column, the expression is
+evaluated once per column, with the \code{.col} pronoun bound to that
+column's own values. If omitted, it defaults to \code{.col}.}
 
 \item{na.color}{Color for missing values}
 

--- a/tests/testthat/test-rule-css.R
+++ b/tests/testthat/test-rule-css.R
@@ -16,3 +16,17 @@ test_that("rule_css recycles a scalar expression to every row", {
     condformat2html()
   expect_equal(lengths(regmatches(out, gregexpr("border-style: solid", out))), 5)
 })
+
+test_that(".col lets one rule_css call style several columns by their own values (#19)", {
+  x <- data.frame(a = c(1, 5), b = c(5, 1))
+  out_col <- x %>%
+    condformat() %>%
+    rule_css(c(a, b), ifelse(.col > 3, "solid", "dashed"), css_field = "border-style") %>%
+    condformat2html()
+  out_chained <- x %>%
+    condformat() %>%
+    rule_css(a, ifelse(a > 3, "solid", "dashed"), css_field = "border-style") %>%
+    rule_css(b, ifelse(b > 3, "solid", "dashed"), css_field = "border-style") %>%
+    condformat2html()
+  expect_equal(out_col, out_chained)
+})

--- a/tests/testthat/test-rule-fill-bar.R
+++ b/tests/testthat/test-rule-fill-bar.R
@@ -73,11 +73,25 @@ test_that("rule_fill_bar lockcells prevents further CSS rules from applying", {
   expect_equal(css_fields$`background-color`[1, 1], "#FF0000")
 })
 
-test_that("rule_fill_bar warns when applied to multiple columns without an explicit expression", {
+test_that("rule_fill_bar applied to multiple columns without an expression uses each column's own values", {
   expect_warning(
-    condformat2html(
+    out <- condformat2html(
       rule_fill_bar(condformat(data.frame(a = 1:3, b = 4:6)), c("a", "b"))),
-    "multiple columns")
+    NA)
+  expect_match(out, "^<table.*</table>$")
+})
+
+test_that(".col lets one rule_fill_bar call use each column's own range (#19)", {
+  out_col <- data.frame(a = 1:3, b = c(10, 20, 40)) %>%
+    condformat() %>%
+    rule_fill_bar(c(a, b), .col) %>%
+    condformat2html()
+  out_chained <- data.frame(a = 1:3, b = c(10, 20, 40)) %>%
+    condformat() %>%
+    rule_fill_bar(a, a) %>%
+    rule_fill_bar(b, b) %>%
+    condformat2html()
+  expect_equal(out_col, out_chained)
 })
 
 test_that("rule_fill_bar is not supported in LaTeX and warns", {

--- a/tests/testthat/test-rule-fill-discrete.R
+++ b/tests/testthat/test-rule-fill-discrete.R
@@ -52,12 +52,27 @@ test_that("rule_fill_discrete lock cells", {
   expect_failure(expect_match(out, "blue"))
 })
 
-test_that("rule_fill_discrete syntax with multiple variables and no expression gives warning", {
+test_that("rule_fill_discrete applied to multiple columns without an expression colors each by its own values", {
   expect_warning(
-    condformat2html(
+    out <- condformat2html(
       rule_fill_discrete(condformat(head(iris)),
                          c("Species", "Sepal.Length"))),
-    "multiple columns")
+    NA)
+  expect_match(out, "^<table.*</table>$")
+})
+
+test_that(".col lets one rule colour several columns by their own values (#19)", {
+  out_col <- condformat(iris[1:5, ]) %>%
+    rule_fill_discrete(c(Sepal.Length, Sepal.Width), .col > 3,
+                       colours = c("TRUE" = "red", "FALSE" = "blue")) %>%
+    condformat2html()
+  out_chained <- condformat(iris[1:5, ]) %>%
+    rule_fill_discrete(Sepal.Length, Sepal.Length > 3,
+                       colours = c("TRUE" = "red", "FALSE" = "blue")) %>%
+    rule_fill_discrete(Sepal.Width, Sepal.Width > 3,
+                       colours = c("TRUE" = "red", "FALSE" = "blue")) %>%
+    condformat2html()
+  expect_equal(out_col, out_chained)
 })
 
 test_that("rule_fill_discrete has expected LaTeX output", {

--- a/tests/testthat/test-rule-fill-gradient.R
+++ b/tests/testthat/test-rule-fill-gradient.R
@@ -23,3 +23,31 @@ test_that("rule_fill_gradient2 works", {
   expect_match(out, "^<table.*</table>$")
   expect_equal(out, out2)
 })
+
+test_that(".col lets one rule_fill_gradient call use each column's own range (#19)", {
+  x <- data.frame(a = c(1, 2, 3), b = c(10, 20, 30))
+  out_col <- x %>%
+    condformat() %>%
+    rule_fill_gradient(c(a, b), .col) %>%
+    condformat2html()
+  out_chained <- x %>%
+    condformat() %>%
+    rule_fill_gradient(a, a) %>%
+    rule_fill_gradient(b, b) %>%
+    condformat2html()
+  expect_equal(out_col, out_chained)
+})
+
+test_that(".col lets one rule_fill_gradient2 call use each column's own range (#19)", {
+  x <- data.frame(a = c(1, 2, 3), b = c(10, 20, 30))
+  out_col <- x %>%
+    condformat() %>%
+    rule_fill_gradient2(c(a, b), .col) %>%
+    condformat2html()
+  out_chained <- x %>%
+    condformat() %>%
+    rule_fill_gradient2(a, a) %>%
+    rule_fill_gradient2(b, b) %>%
+    condformat2html()
+  expect_equal(out_col, out_chained)
+})

--- a/tests/testthat/test-rule-text-bold.R
+++ b/tests/testthat/test-rule-text-bold.R
@@ -26,6 +26,20 @@ test_that("rule_text_bold recycles a scalar expression to every row", {
   expect_equal(lengths(regmatches(out, gregexpr("font-weight: bold", out))), 5)
 })
 
+test_that(".col lets one rule_text_bold call bold several columns by their own values (#19)", {
+  x <- data.frame(a = c(1, 5), b = c(5, 1))
+  out_col <- x %>%
+    condformat() %>%
+    rule_text_bold(c(a, b), .col > 3) %>%
+    condformat2html()
+  out_chained <- x %>%
+    condformat() %>%
+    rule_text_bold(a, a > 3) %>%
+    rule_text_bold(b, b > 3) %>%
+    condformat2html()
+  expect_equal(out_col, out_chained)
+})
+
 test_that("rule_text_bold lockcells prevents further LaTeX rules from applying", {
   out <- condformat(data.frame(a = "potato")) %>%
     rule_text_bold("a", expression = TRUE, lockcells = TRUE) %>%

--- a/tests/testthat/test-rule-text-color.R
+++ b/tests/testthat/test-rule-text-color.R
@@ -17,6 +17,20 @@ test_that("rule_text_color recycles a scalar expression to every row", {
   expect_equal(lengths(regmatches(out, gregexpr("color: red", out))), 5)
 })
 
+test_that(".col lets one rule_text_color call colour several columns by their own values (#19)", {
+  x <- data.frame(a = c(1, 5), b = c(5, 1))
+  out_col <- x %>%
+    condformat() %>%
+    rule_text_color(c(a, b), ifelse(.col > 3, "red", "blue")) %>%
+    condformat2html()
+  out_chained <- x %>%
+    condformat() %>%
+    rule_text_color(a, ifelse(a > 3, "red", "blue")) %>%
+    rule_text_color(b, ifelse(b > 3, "red", "blue")) %>%
+    condformat2html()
+  expect_equal(out_col, out_chained)
+})
+
 test_that("rule_text_color lockcells prevents further LaTeX rules from applying", {
   out <- condformat(data.frame(a = "potato")) %>%
     rule_text_color("a", expression = "red", lockcells = TRUE) %>%

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -41,3 +41,27 @@ condformat(iris[c(1:5,70:75, 120:125),]) %>%
   rule_fill_bar(Petal.Width, limits = c(0, NA))
 ```
 
+## The `.col` pronoun
+
+When a rule targets several columns at once, its `expression` can use the
+`.col` pronoun to refer to each targeted column's own values, instead of a
+single shared expression applied identically to every column. This:
+
+```{r, eval = FALSE}
+condformat(iris) %>%
+  rule_fill_discrete(c(Sepal.Length, Sepal.Width), .col > 3)
+```
+
+is equivalent to chaining the rule once per column:
+
+```{r, eval = FALSE}
+condformat(iris) %>%
+  rule_fill_discrete(Sepal.Length, Sepal.Length > 3) %>%
+  rule_fill_discrete(Sepal.Width, Sepal.Width > 3)
+```
+
+`.col` works the same way in `rule_fill_gradient()`, `rule_fill_gradient2()`,
+`rule_fill_bar()`, `rule_text_bold()`, `rule_text_color()` and `rule_css()`.
+If `expression` is omitted entirely, it now defaults to `.col`, so each
+selected column is formatted based on its own values.
+


### PR DESCRIPTION
## Summary

Closes #19. Every CSS-based rule (`rule_fill_discrete`, `rule_fill_gradient`, `rule_fill_gradient2`, `rule_fill_bar`, `rule_text_bold`, `rule_text_color`, `rule_css`) evaluated its `expression` once and broadcast the result identically to every selected column, so a multi-column rule call couldn't express "each column's own condition" — only a shared one, or (with no expression) a warning-and-first-column-only fallback.

- Added a shared `eval_expression_per_column()` helper (`rule_helper.R`) that evaluates the expression once per selected column, with a `.col` pronoun bound in the data mask to that column's own values. Wired it into all seven rules, replacing each rule's "evaluate once, `mat[, columns] <- value`" pattern with a per-column loop that also recomputes any auto-detected `limits`/`midpoint`/palette from that column alone — matching the semantics of chaining the rule once per column:

  ```r
  # These two are now equivalent:
  condformat(iris) %>% rule_fill_discrete(c(Sepal.Length, Sepal.Width), .col > 3)

  condformat(iris) %>%
    rule_fill_discrete(Sepal.Length, Sepal.Length > 3) %>%
    rule_fill_discrete(Sepal.Width, Sepal.Width > 3)
  ```

- `expression` now also defaults to `.col` when omitted, replacing the previous "applied to multiple columns, using column X ... please use an explicit expression" warning — each column now correctly uses its own values by default instead of silently only the first one.
- While rewriting `rule_text_bold`'s per-column assignment, replaced its row-selector matrix indexing (`bold_or_not_mat[bold_or_not, columns] <- "bold"`) with an `ifelse()`-based approach that can't hit R's "NAs are not allowed in subscripted assignments" error if the expression evaluates to `NA` for some rows; also dropped an unused, vestigial intermediate matrix in the same function.

## A related, separate finding (not fixed here)

While touching `rule_css.R`, I noticed its `na.value` constructor argument is accepted, documented, and stored on the rule object, but `rule_to_cf_field.rule_css` never actually reads `rule[["na.value"]]` — so it's a dead parameter (unlike every other rule, where `na.value` is applied). Left as-is since it's an unrelated, pre-existing gap and a behavior change of its own; happy to fix in a follow-up if wanted.

## Test plan
- [x] Added a regression test per rule confirming the `.col`-based single-rule call produces output identical to chaining the rule once per column
- [x] Updated the two existing tests that asserted the now-removed multi-column warning
- [x] Updated roxygen docs, man pages (hand-synced since `devtools::document()` isn't available in this environment — worth a sanity check with `devtools::document()` before merge), and the introduction vignette
- [ ] CI runs green


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_