### PR TITLE
Bump minimum dependency versions to latest CRAN releases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,26 +20,26 @@ Description: Apply and visualize conditional formatting to data frames in R.
 License: BSD_3_clause + file LICENSE
 NeedsCompilation: no
 Imports:
-    dplyr (>= 0.7.7),
+    dplyr (>= 1.2.1),
     grDevices,
-    gridExtra (>= 2.3),
-    gtable (>= 0.2.0),
-    htmlTable (>= 1.9),
-    htmltools (>= 0.3.6),
-    knitr (>= 1.20),
+    gridExtra (>= 2.3.1),
+    gtable (>= 0.3.6),
+    htmlTable (>= 2.5.0),
+    htmltools (>= 0.5.9),
+    knitr (>= 1.51),
     magrittr (>= 1.5),
-    openxlsx (>= 4.1.5),
-    rmarkdown (>= 1.10),
-    rlang (>= 0.3.0),
-    scales (>= 1.0.0),
-    tibble (>= 1.3.4),
-    tidyselect (>= 1.0.0)
+    openxlsx (>= 4.2.8.1),
+    rmarkdown (>= 2.31),
+    rlang (>= 1.3.0),
+    scales (>= 1.4.0),
+    tibble (>= 3.3.1),
+    tidyselect (>= 1.2.1)
 Suggests:
     promises,
-    shiny (>= 1.0.5),
-    testthat (>= 1.0),
-    vdiffr (>= 1.0.4)
+    shiny (>= 1.14.0),
+    testthat (>= 3.3.2),
+    vdiffr (>= 1.0.9)
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,25 +20,25 @@ Description: Apply and visualize conditional formatting to data frames in R.
 License: BSD_3_clause + file LICENSE
 NeedsCompilation: no
 Imports:
-    dplyr (>= 1.2.1),
+    dplyr (>= 1.1.4),
     grDevices,
-    gridExtra (>= 2.3.1),
+    gridExtra (>= 2.3),
     gtable (>= 0.3.6),
-    htmlTable (>= 2.5.0),
-    htmltools (>= 0.5.9),
-    knitr (>= 1.51),
+    htmlTable (>= 2.4.3),
+    htmltools (>= 0.5.8.1),
+    knitr (>= 1.50),
     magrittr (>= 1.5),
-    openxlsx (>= 4.2.8.1),
-    rmarkdown (>= 2.31),
-    rlang (>= 1.3.0),
+    openxlsx (>= 4.2.8),
+    rmarkdown (>= 2.29),
+    rlang (>= 1.1.6),
     scales (>= 1.4.0),
-    tibble (>= 3.3.1),
+    tibble (>= 3.3.0),
     tidyselect (>= 1.2.1)
 Suggests:
     promises,
-    shiny (>= 1.14.0),
-    testthat (>= 3.3.2),
-    vdiffr (>= 1.0.9)
+    shiny (>= 1.11.1),
+    testthat (>= 3.2.3),
+    vdiffr (>= 1.0.8)
 VignetteBuilder: knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,16 @@
 
 ## Dependencies
 
-* Bump the minimum required version of all versioned dependencies to their
-  latest CRAN release, to test and develop against currently supported
-  releases (part of #43): `dplyr` (>= 1.2.1), `gridExtra` (>= 2.3.1),
-  `gtable` (>= 0.3.6), `htmlTable` (>= 2.5.0), `htmltools` (>= 0.5.9),
-  `knitr` (>= 1.51), `openxlsx` (>= 4.2.8.1), `rmarkdown` (>= 2.31),
-  `rlang` (>= 1.3.0), `scales` (>= 1.4.0), `tibble` (>= 3.3.1),
-  `tidyselect` (>= 1.2.1), `shiny` (>= 1.14.0), `testthat` (>= 3.3.2) and
-  `vdiffr` (>= 1.0.9).
+* Bump the minimum required version of all versioned dependencies to the
+  release that was current about a year ago, rather than today's exact
+  latest release, so users aren't forced onto a brand new patch just to
+  install condformat (part of #43): `dplyr` (>= 1.1.4), `gtable` (>= 0.3.6),
+  `htmlTable` (>= 2.4.3), `htmltools` (>= 0.5.8.1), `knitr` (>= 1.50),
+  `openxlsx` (>= 4.2.8), `rmarkdown` (>= 2.29), `rlang` (>= 1.1.6),
+  `scales` (>= 1.4.0), `tibble` (>= 3.3.0), `tidyselect` (>= 1.2.1),
+  `shiny` (>= 1.11.1), `testthat` (>= 3.2.3) and `vdiffr` (>= 1.0.8).
+  `gridExtra`'s floor (>= 2.3) is unchanged, as that release is still the
+  latest on CRAN as of a year ago.
 
 ## New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # condformat 0.10.1.9000
 
+## Dependencies
+
+* Bump the minimum required version of all versioned dependencies to their
+  latest CRAN release, to test and develop against currently supported
+  releases (part of #43): `dplyr` (>= 1.2.1), `gridExtra` (>= 2.3.1),
+  `gtable` (>= 0.3.6), `htmlTable` (>= 2.5.0), `htmltools` (>= 0.5.9),
+  `knitr` (>= 1.51), `openxlsx` (>= 4.2.8.1), `rmarkdown` (>= 2.31),
+  `rlang` (>= 1.3.0), `scales` (>= 1.4.0), `tibble` (>= 3.3.1),
+  `tidyselect` (>= 1.2.1), `shiny` (>= 1.14.0), `testthat` (>= 3.3.2) and
+  `vdiffr` (>= 1.0.9).
+
 ## New features
 
 * Add a `.col` pronoun usable in the `expression` argument of `rule_fill_discrete()`,

--- a/man/condformat2grob.Rd
+++ b/man/condformat2grob.Rd
@@ -12,7 +12,7 @@ condformat2grob(x, draw = TRUE)
 \item{draw}{A logical. If \code{TRUE} (default), the table is
 immediately drawn using \code{grid::draw()} and the grob is returned.
 If \code{FALSE}, the grob is returned without drawing. Set \code{draw=FALSE}
-when using the grob in composite images with \code{\link[gridExtra:arrangeGrob]{gridExtra::grid.arrange()}} or
+when using the grob in composite images with \code{\link[gridExtra:grid.arrange]{gridExtra::grid.arrange()}} or
 \code{ggpubr::ggarrange()}.}
 }
 \value{

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:\%>\%]{\%>\%}}}
 }}
 

--- a/man/rule_css.Rd
+++ b/man/rule_css.Rd
@@ -36,12 +36,12 @@ print(cf)
 }
 }
 \seealso{
-Other rule: 
-\code{\link{rule_fill_bar}()},
-\code{\link{rule_fill_discrete}()},
-\code{\link{rule_fill_gradient2}()},
-\code{\link{rule_fill_gradient}()},
-\code{\link{rule_text_bold}()},
-\code{\link{rule_text_color}()}
+Other rule:
+\code{\link[=rule_fill_bar]{rule_fill_bar()}},
+\code{\link[=rule_fill_discrete]{rule_fill_discrete()}},
+\code{\link[=rule_fill_gradient]{rule_fill_gradient()}},
+\code{\link[=rule_fill_gradient2]{rule_fill_gradient2()}},
+\code{\link[=rule_text_bold]{rule_text_bold()}},
+\code{\link[=rule_text_color]{rule_text_color()}}
 }
 \concept{rule}

--- a/man/rule_fill_bar.Rd
+++ b/man/rule_fill_bar.Rd
@@ -57,12 +57,12 @@ print(cf)
 }
 }
 \seealso{
-Other rule: 
-\code{\link{rule_css}()},
-\code{\link{rule_fill_discrete}()},
-\code{\link{rule_fill_gradient2}()},
-\code{\link{rule_fill_gradient}()},
-\code{\link{rule_text_bold}()},
-\code{\link{rule_text_color}()}
+Other rule:
+\code{\link[=rule_css]{rule_css()}},
+\code{\link[=rule_fill_discrete]{rule_fill_discrete()}},
+\code{\link[=rule_fill_gradient]{rule_fill_gradient()}},
+\code{\link[=rule_fill_gradient2]{rule_fill_gradient2()}},
+\code{\link[=rule_text_bold]{rule_text_bold()}},
+\code{\link[=rule_text_color]{rule_text_color()}}
 }
 \concept{rule}

--- a/man/rule_fill_discrete.Rd
+++ b/man/rule_fill_discrete.Rd
@@ -87,12 +87,12 @@ print(cf)
 }
 }
 \seealso{
-Other rule: 
-\code{\link{rule_css}()},
-\code{\link{rule_fill_bar}()},
-\code{\link{rule_fill_gradient2}()},
-\code{\link{rule_fill_gradient}()},
-\code{\link{rule_text_bold}()},
-\code{\link{rule_text_color}()}
+Other rule:
+\code{\link[=rule_css]{rule_css()}},
+\code{\link[=rule_fill_bar]{rule_fill_bar()}},
+\code{\link[=rule_fill_gradient]{rule_fill_gradient()}},
+\code{\link[=rule_fill_gradient2]{rule_fill_gradient2()}},
+\code{\link[=rule_text_bold]{rule_text_bold()}},
+\code{\link[=rule_text_color]{rule_text_color()}}
 }
 \concept{rule}

--- a/man/rule_fill_gradient.Rd
+++ b/man/rule_fill_gradient.Rd
@@ -68,12 +68,12 @@ print(cf)
 
 }
 \seealso{
-Other rule: 
-\code{\link{rule_css}()},
-\code{\link{rule_fill_bar}()},
-\code{\link{rule_fill_discrete}()},
-\code{\link{rule_fill_gradient2}()},
-\code{\link{rule_text_bold}()},
-\code{\link{rule_text_color}()}
+Other rule:
+\code{\link[=rule_css]{rule_css()}},
+\code{\link[=rule_fill_bar]{rule_fill_bar()}},
+\code{\link[=rule_fill_discrete]{rule_fill_discrete()}},
+\code{\link[=rule_fill_gradient2]{rule_fill_gradient2()}},
+\code{\link[=rule_text_bold]{rule_text_bold()}},
+\code{\link[=rule_text_color]{rule_text_color()}}
 }
 \concept{rule}

--- a/man/rule_fill_gradient2.Rd
+++ b/man/rule_fill_gradient2.Rd
@@ -74,12 +74,12 @@ print(cf)
 
 }
 \seealso{
-Other rule: 
-\code{\link{rule_css}()},
-\code{\link{rule_fill_bar}()},
-\code{\link{rule_fill_discrete}()},
-\code{\link{rule_fill_gradient}()},
-\code{\link{rule_text_bold}()},
-\code{\link{rule_text_color}()}
+Other rule:
+\code{\link[=rule_css]{rule_css()}},
+\code{\link[=rule_fill_bar]{rule_fill_bar()}},
+\code{\link[=rule_fill_discrete]{rule_fill_discrete()}},
+\code{\link[=rule_fill_gradient]{rule_fill_gradient()}},
+\code{\link[=rule_text_bold]{rule_text_bold()}},
+\code{\link[=rule_text_color]{rule_text_color()}}
 }
 \concept{rule}

--- a/man/rule_text_bold.Rd
+++ b/man/rule_text_bold.Rd
@@ -33,12 +33,12 @@ print(cf)
 }
 }
 \seealso{
-Other rule: 
-\code{\link{rule_css}()},
-\code{\link{rule_fill_bar}()},
-\code{\link{rule_fill_discrete}()},
-\code{\link{rule_fill_gradient2}()},
-\code{\link{rule_fill_gradient}()},
-\code{\link{rule_text_color}()}
+Other rule:
+\code{\link[=rule_css]{rule_css()}},
+\code{\link[=rule_fill_bar]{rule_fill_bar()}},
+\code{\link[=rule_fill_discrete]{rule_fill_discrete()}},
+\code{\link[=rule_fill_gradient]{rule_fill_gradient()}},
+\code{\link[=rule_fill_gradient2]{rule_fill_gradient2()}},
+\code{\link[=rule_text_color]{rule_text_color()}}
 }
 \concept{rule}

--- a/man/rule_text_color.Rd
+++ b/man/rule_text_color.Rd
@@ -33,12 +33,12 @@ print(cf)
 }
 }
 \seealso{
-Other rule: 
-\code{\link{rule_css}()},
-\code{\link{rule_fill_bar}()},
-\code{\link{rule_fill_discrete}()},
-\code{\link{rule_fill_gradient2}()},
-\code{\link{rule_fill_gradient}()},
-\code{\link{rule_text_bold}()}
+Other rule:
+\code{\link[=rule_css]{rule_css()}},
+\code{\link[=rule_fill_bar]{rule_fill_bar()}},
+\code{\link[=rule_fill_discrete]{rule_fill_discrete()}},
+\code{\link[=rule_fill_gradient]{rule_fill_gradient()}},
+\code{\link[=rule_fill_gradient2]{rule_fill_gradient2()}},
+\code{\link[=rule_text_bold]{rule_text_bold()}}
 }
 \concept{rule}


### PR DESCRIPTION
## Summary

- Part of #43 ("Review dependencies"): "Check each dependency for its latest major version and iff we have a versioned dependency (e.g. `dplyr >=0.7.7`) bump it to the latest major version."
- **Policy**: bump each already-versioned floor to the release that was current about **one year ago** (2025-07-09), not today's exact latest patch. Pinning to the bleeding-edge release would force every user to upgrade just to install condformat; using a ~1-year-old floor still retires genuinely stale requirements (e.g. `dplyr >= 0.7.7` from 2018) while leaving plenty of headroom for users on a recent-but-not-brand-new install.
- `promises` has no version floor today and is left unversioned, per "iff we have a versioned dependency."
- `magrittr` is untouched here — it's being removed entirely in a separate PR (#46).

| Package | Old floor | New floor | New floor released |
|---|---|---|---|
| dplyr | >=0.7.7 | >=1.1.4 | 2023-11-17 |
| gridExtra | >=2.3 | >=2.3 (unchanged) | 2017-09-09 — still latest as of a year ago |
| gtable | >=0.2.0 | >=0.3.6 | 2024-10-25 |
| htmlTable | >=1.9 | >=2.4.3 | 2024-07-21 |
| htmltools | >=0.3.6 | >=0.5.8.1 | 2024-04-04 |
| knitr | >=1.20 | >=1.50 | 2025-03-16 |
| openxlsx | >=4.1.5 | >=4.2.8 | 2025-01-25 |
| rmarkdown | >=1.10 | >=2.29 | 2024-11-04 |
| rlang | >=0.3.0 | >=1.1.6 | 2025-04-11 |
| scales | >=1.0.0 | >=1.4.0 | 2025-04-24 |
| tibble | >=1.3.4 | >=3.3.0 | 2025-06-08 |
| tidyselect | >=1.0.0 | >=1.2.1 | 2024-03-11 |
| shiny (Suggests) | >=1.0.5 | >=1.11.1 | 2025-07-03 |
| testthat (Suggests) | >=1.0 | >=3.2.3 | 2025-01-13 |
| vdiffr (Suggests) | >=1.0.4 | >=1.0.8 | 2024-10-31 |

## Test plan

- [x] `rcmdcheck::rcmdcheck()` on R 4.6.1: 0 errors, 0 notes, only the pre-existing environment-only locale warning (this sandbox lacks the `en_US.UTF-8` locale).
- [x] Full test suite and vignette re-build pass.
