### PR TITLE
Fix the bundled shiny example

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,14 @@
   `rule_fill_gradient2()` and `rule_fill_bar()`, which already recycled such
   values to every row.
 
+## Other
+
+* Fix the bundled shiny example (`inst/shinyexample/`): `requireNamespace()`
+  now passes `quietly = TRUE`, so it no longer prints a package-startup
+  message every time the optional `colourpicker` dependency isn't installed.
+  Also modernised the legacy `shinyUI()`/`shinyServer()` wrappers to the
+  current `ui <- ...` / `server <- function(input, output) {...}` style.
+
 # condformat 0.10.1
 
 ## Fixes

--- a/inst/shinyexample/server.R
+++ b/inst/shinyexample/server.R
@@ -12,7 +12,7 @@ library(condformat)
 data(iris)
 
 # Define server logic required to show condformat usage
-shinyServer(function(input, output) {
+server <- function(input, output) {
   output$iris <- renderCondformat({
     x <- condformat(iris)
     column1 <- input$gradientcol1
@@ -39,4 +39,4 @@ shinyServer(function(input, output) {
     }
     x %>% theme_htmlWidget(number_of_entries = num_entries)
     })
-})
+}

--- a/inst/shinyexample/ui.R
+++ b/inst/shinyexample/ui.R
@@ -15,7 +15,7 @@ data(iris)
 # install.packages("colourpicker")
 # to get a nice colour picker in shiny. This is a workaround
 colourpick <- function(inputId, label, value = "purple") {
-  if (!requireNamespace("colourpicker")) {
+  if (!requireNamespace("colourpicker", quietly = TRUE)) {
     return(textInput(inputId = inputId, label = label, value = value))
   } else {
     colourpicker::colourInput(inputId = inputId, label = label, value = value)
@@ -23,7 +23,7 @@ colourpick <- function(inputId, label, value = "purple") {
 }
 
 # Define UI for application that draws a histogram
-shinyUI(fluidPage(
+ui <- fluidPage(
 
   # Application title
   titlePanel("Condformat example"),
@@ -46,4 +46,4 @@ shinyUI(fluidPage(
        condformatOutput("iris")
     )
   )
-))
+)


### PR DESCRIPTION
## Summary

Part of #43 ("Review the shiny app example for potential issues"):

- `inst/shinyexample/ui.R`: `requireNamespace("colourpicker")` was missing `quietly = TRUE`. This meant that on every app load where the optional `colourpicker` package isn't installed, R printed a package-loading-style message to the console just from probing whether the namespace *could* be loaded.
- Modernised the legacy `shinyUI(fluidPage(...))` / `shinyServer(function(input, output) {...})` wrappers in `ui.R`/`server.R` to the current, recommended `ui <- fluidPage(...)` / `server <- function(input, output) {...}` two-file app style.

No functional/rendering logic changed — the `rule_fill_gradient(!! column1, ...)` / `rule_fill_discrete("Species")` calls in `server.R` were already correct.

## Test plan

- [x] Both files parse cleanly (`parse()`).
- [x] Smoke-tested by launching the app with `shiny::runApp("inst/shinyexample", launch.browser = FALSE)` and confirming it serves an HTTP 200 response with the expected `"Condformat example"` title, with no errors in the server log.
- [x] `rcmdcheck::rcmdcheck()`: 0 errors (same 1 warning / 1 note as the other PRs in this series, both artifacts of the sandboxed check environment, not the package).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_