### PR TITLE
Preserve pre-existing xlsx cell styles instead of silently discarding them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,12 @@
 
 ## Fixes
 
+* Fix `condformat2excel()`/`condformat2excelsheet()` silently discarding any
+  pre-existing cell formatting on every export — including a Date column's
+  automatic format from `openxlsx::writeData()` — even for cells with no
+  condformat rule applied to them. `condformat2excelsheet()`'s own styling
+  now uses `stack = TRUE` internally, so it merges with, rather than
+  replaces, formatting that was already there (related to #25).
 * Fix `lockcells = TRUE` being ignored (or worse, unlocking cells) for LaTeX
   and grob/gtable output in `rule_fill_discrete()`, `rule_fill_gradient()`,
   `rule_fill_gradient2()`, `rule_text_bold()` and `rule_text_color()`. HTML

--- a/R/render_xlsx.R
+++ b/R/render_xlsx.R
@@ -54,13 +54,17 @@ condformat2excel <- function(x, filename, sheet_name = "Sheet1",
 #' worksheet) yourself, so you can add other sheets, or apply additional
 #' `openxlsx` formatting, before saving it with [openxlsx::saveWorkbook()].
 #'
-#' [openxlsx::addStyle()] replaces any style already present at a cell
-#' unless you pass `stack = TRUE`, in which case it merges the new style
-#' with the existing one instead. Since this function already applies a
-#' style (fill colour, bold, font colour) to every cell, remember to pass
-#' `stack = TRUE` to your own `openxlsx::addStyle()` calls if you want your
-#' formatting (e.g. a number format) to combine with condformat's, rather
-#' than replacing it. See the example below.
+#' This function applies its own styling (fill colour, bold, font colour) to
+#' every cell using `stack = TRUE`, so it merges with, rather than replaces,
+#' any formatting you already applied (e.g. a number format on a Date column,
+#' set either by you or automatically by [openxlsx::writeData()]).
+#'
+#' [openxlsx::addStyle()] itself defaults to replacing, not merging, any
+#' style already present at a cell. So if you add your own `openxlsx`
+#' formatting *after* calling this function, remember to pass
+#' `stack = TRUE` to your own call too, or it will silently replace
+#' condformat's own styling instead of combining with it. See the example
+#' below.
 #'
 #' @param x A condformat object, typically created with [condformat()]
 #' @param workbook An `openxlsx` Workbook object, as created with
@@ -153,7 +157,7 @@ condformat2excelsheet <- function(x, workbook, sheet_name) {
         )
         created_styles[[style_hash]] <- cell_style
       }
-      openxlsx::addStyle(workbook, sheet_name, style = cell_style, rows = i + 1, cols = j)
+      openxlsx::addStyle(workbook, sheet_name, style = cell_style, rows = i + 1, cols = j, stack = TRUE)
     }
   }
   openxlsx::setColWidths(workbook, sheet = sheet_name, cols = seq_len(ncol(xview)), widths = "auto")

--- a/man/condformat2excelsheet.Rd
+++ b/man/condformat2excelsheet.Rd
@@ -23,13 +23,17 @@ worksheet) yourself, so you can add other sheets, or apply additional
 \code{openxlsx} formatting, before saving it with \code{\link[openxlsx:saveWorkbook]{openxlsx::saveWorkbook()}}.
 }
 \details{
-\code{\link[openxlsx:addStyle]{openxlsx::addStyle()}} replaces any style already present at a cell
-unless you pass \code{stack = TRUE}, in which case it merges the new style
-with the existing one instead. Since this function already applies a
-style (fill colour, bold, font colour) to every cell, remember to pass
-\code{stack = TRUE} to your own \code{openxlsx::addStyle()} calls if you want your
-formatting (e.g. a number format) to combine with condformat's, rather
-than replacing it. See the example below.
+This function applies its own styling (fill colour, bold, font colour) to
+every cell using \code{stack = TRUE}, so it merges with, rather than replaces,
+any formatting you already applied (e.g. a number format on a Date column,
+set either by you or automatically by \code{\link[openxlsx:writeData]{openxlsx::writeData()}}).
+
+\code{\link[openxlsx:addStyle]{openxlsx::addStyle()}} itself defaults to replacing, not merging, any
+style already present at a cell. So if you add your own \code{openxlsx}
+formatting \emph{after} calling this function, remember to pass
+\code{stack = TRUE} to your own call too, or it will silently replace
+condformat's own styling instead of combining with it. See the example
+below.
 }
 \examples{
 data(iris)

--- a/tests/testthat/test-render-excel.R
+++ b/tests/testthat/test-render-excel.R
@@ -116,3 +116,52 @@ test_that("condformat2excel applies and caches fill/bold/color styles across rep
   expect_true(length(workbook$styleObjects) > 0)
   expect_equal(nrow(openxlsx::read.xlsx(filename, 1)), 6)
 })
+
+test_that("condformat2excel preserves openxlsx's automatic Date column format", {
+  # openxlsx::writeData() auto-applies a Date number format to Date columns.
+  # condformat2excelsheet's own per-cell styling (applied to every cell, even
+  # ones with no rule) must not silently reset it back to General.
+  df <- data.frame(
+    id = 1:3,
+    d = as.Date(c("2024-01-01", "2024-06-15", "2024-12-31")),
+    grp = c("a", "b", "a")
+  )
+  cf <- condformat(df) |> rule_fill_discrete("grp")
+  filename <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(filename))
+  condformat2excel(cf, filename = filename)
+  workbook <- openxlsx::loadWorkbook(filename)
+  date_col <- which(names(df) == "d")
+  date_styles <- Filter(function(s) date_col %in% s$cols, workbook$styleObjects)
+  expect_true(length(date_styles) > 0)
+  expect_true(all(vapply(date_styles, function(s) {
+    !is.null(s$style$numFmt) && identical(s$style$numFmt$numFmtId, "14")
+  }, logical(1))))
+})
+
+test_that("condformat2excelsheet merges with, rather than replaces, pre-existing cell styles", {
+  # In-memory workbook$styleObjects can contain multiple overlapping, not yet
+  # reconciled entries for the same cell; only a save+reload round trip
+  # reflects what actually ends up rendered, so we check that.
+  df <- data.frame(id = 1:3, note = c("a", "b", "c"))
+  cf <- condformat(df) # no rules at all: every cell gets an "empty" style
+  workbook <- openxlsx::createWorkbook(creator = "")
+  openxlsx::addWorksheet(workbook, sheetName = "sheet1")
+  # Simulate a user pre-applying their own formatting before calling
+  # condformat2excelsheet, e.g. a currency-like number format on "id":
+  openxlsx::addStyle(
+    workbook, "sheet1",
+    style = openxlsx::createStyle(numFmt = "$#,##0.00"),
+    rows = 2:4, cols = 1
+  )
+  condformat2excelsheet(cf, workbook, "sheet1")
+  filename <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(filename))
+  openxlsx::saveWorkbook(workbook, file = filename, overwrite = TRUE)
+  reloaded <- openxlsx::loadWorkbook(filename)
+  id_styles <- Filter(function(s) 1 %in% s$cols, reloaded$styleObjects)
+  expect_true(length(id_styles) > 0)
+  expect_true(all(vapply(id_styles, function(s) {
+    !is.null(s$style$numFmt) && identical(s$style$numFmt$formatCode, "$#,##0.00")
+  }, logical(1))))
+})


### PR DESCRIPTION
## Summary

Follow-up to #48/#25. While documenting how to combine condformat's own cell styling with a caller's own `openxlsx` formatting via `stack = TRUE`, I found the underlying issue is broader than just that documented workaround.

- `condformat2excelsheet()` calls `openxlsx::addStyle()` for **every** cell of the table, even ones with no condformat rule applied to them. Without `stack = TRUE`, `addStyle()` replaces (rather than merges with) whatever style is already at a cell.
- This means condformat silently discarded **any** pre-existing formatting on every single export — including `openxlsx::writeData()`'s own automatic Date-column number format — regardless of whether that particular cell had a rule targeting it.
- Fix: pass `stack = TRUE` on condformat's own internal `addStyle()` call. Verified `openxlsx`'s merge only applies explicitly-set style attributes, so this doesn't clobber a pre-existing `numFmt`, fill colour, or font with `createStyle()`'s own defaults on cells condformat doesn't actually want to style.
- Updated `condformat2excelsheet()`'s docs: this changes which *side* of a stacking pair needs `stack = TRUE`. Styling applied **before** calling this function is now preserved automatically. A caller's own `openxlsx` calls made **after** it still need `stack = TRUE` themselves (unchanged from #48's docs) to combine rather than replace condformat's own styling.

## Test plan

- [x] Added a regression test confirming a Date column's automatic `openxlsx::writeData()` format survives `condformat2excel()` when a rule targets a *different* column.
- [x] Added a regression test confirming a caller's own pre-applied cell style (e.g. a currency `numFmt`) on a cell with no condformat rule survives `condformat2excelsheet()`, verified through an actual save+reload round trip (in-memory `workbook$styleObjects` can hold multiple unreconciled overlapping entries, so I don't rely on that alone).
- [x] Confirmed both new tests fail without the fix (`stack = FALSE`) and pass with it.
- [x] `rcmdcheck::rcmdcheck()` on R 4.6.1: 0 errors, only the pre-existing environment-only locale warning/note (this sandbox lacks the `en_US.UTF-8` locale and has a stray local `.claude` dir).
- [x] Full test suite passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_