### PR TITLE
Move gridExtra, gtable, openxlsx and rmarkdown to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,19 +24,19 @@ Depends:
 Imports:
     dplyr (>= 1.1.4),
     grDevices,
-    gridExtra (>= 2.3),
-    gtable (>= 0.3.6),
     htmlTable (>= 2.4.3),
     htmltools (>= 0.5.8.1),
     knitr (>= 1.50),
-    openxlsx (>= 4.2.8),
-    rmarkdown (>= 2.29),
     rlang (>= 1.1.6),
     scales (>= 1.4.0),
     tibble (>= 3.3.0),
     tidyselect (>= 1.2.1)
 Suggests:
+    gridExtra (>= 2.3),
+    gtable (>= 0.3.6),
+    openxlsx (>= 4.2.8),
     promises,
+    rmarkdown (>= 2.29),
     shiny (>= 1.11.1),
     testthat (>= 3.2.3),
     vdiffr (>= 1.0.8)

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,16 @@
 
 ## Dependencies
 
+* Move `gridExtra`, `gtable`, `openxlsx` and `rmarkdown` from `Imports` to
+  `Suggests`. These are each only needed for one specific, optional output
+  path: `openxlsx` for `condformat2excel()`/`condformat2excelsheet()`,
+  `gridExtra`/`gtable` for `condformat2grob()`/`theme_grob()`, and
+  `rmarkdown` for LaTeX/PDF output via `knit_print()`. If you only ever use
+  condformat's default HTML/RStudio-viewer printing, you no longer need to
+  install any of these. Calling one of the functions above without the
+  corresponding package installed now stops with a clear
+  `install.packages(...)` hint instead of a generic "there is no package
+  called" error, or (for `rmarkdown`) failing deep inside `knit_print()`.
 * Bump the minimum required version of all versioned dependencies to the
   release that was current about a year ago, rather than today's exact
   latest release, so users aren't forced onto a brand new patch just to

--- a/R/condformat_render.R
+++ b/R/condformat_render.R
@@ -34,6 +34,7 @@ condformat2html_or_widget <- function(x, paginate = TRUE) {
 #' @export
 knit_print.condformat_tbl <- function(x, ...) {
   if (knitr::is_latex_output()) {
+    require_suggested_package("rmarkdown", "LaTeX/PDF output from condformat")
     latex_dependencies <- list(rmarkdown::latex_dependency(name = "xcolor",
                                                            options = "table"))
     use_longtable <- knitr::opts_current$get("longtable")

--- a/R/render_gtable.R
+++ b/R/render_gtable.R
@@ -1,5 +1,7 @@
 #' Converts the table to a grid object
 #'
+#' Requires the `gridExtra` package (`install.packages("gridExtra")`).
+#'
 #' @param x A condformat_tbl object
 #' @param draw A logical. If `TRUE` (default), the table is
 #' immediately drawn using `grid::draw()` and the grob is returned.
@@ -9,12 +11,15 @@
 #' @return the grid object
 #' @examples
 #' library(condformat)
-#' data.frame(Student = c("Alice", "Bob", "Charlie"),
-#'            Evaluation = c("Great", "Well done", "Good job!")) |>
-#'  condformat() |>
-#'  condformat2grob()
+#' if (requireNamespace("gridExtra", quietly = TRUE)) {
+#'   data.frame(Student = c("Alice", "Bob", "Charlie"),
+#'              Evaluation = c("Great", "Well done", "Good job!")) |>
+#'    condformat() |>
+#'    condformat2grob()
+#' }
 #' @export
 condformat2grob <- function(x, draw=TRUE) {
+  require_suggested_package("gridExtra", "condformat2grob()")
   xv_cf <- get_xview_and_cf_fields(x)
   xview <- xv_cf[["xview"]]
   cf_fields <- xv_cf[["cf_fields"]]

--- a/R/render_xlsx.R
+++ b/R/render_xlsx.R
@@ -1,5 +1,7 @@
 #' Writes the table to an Excel workbook
 #'
+#' Requires the `openxlsx` package (`install.packages("openxlsx")`).
+#'
 #' @param x A condformat_tbl object
 #' @param filename The xlsx file name.
 #' @param sheet_name The name of the sheet where the table will be written
@@ -13,6 +15,7 @@
 condformat2excel <- function(x, filename, sheet_name = "Sheet1",
                              overwrite_wb = FALSE,
                              overwrite_sheet = TRUE) {
+  require_suggested_package("openxlsx", "condformat2excel() and condformat2excelsheet()")
 
   if (!grepl(pattern = '\\.xlsx$', filename)) { # endsWith(filename, ".xlsx")
     filename <- paste0(filename, ".xlsx")
@@ -48,6 +51,8 @@ condformat2excel <- function(x, filename, sheet_name = "Sheet1",
 }
 
 #' Writes the table to a worksheet of an existing Excel workbook
+#'
+#' Requires the `openxlsx` package (`install.packages("openxlsx")`).
 #'
 #' Unlike [condformat2excel()], this does not create the workbook or save it
 #' to disk: you pass in an `openxlsx` workbook (and an already-added
@@ -95,6 +100,7 @@ condformat2excel <- function(x, filename, sheet_name = "Sheet1",
 #' openxlsx::saveWorkbook(workbook, file = "iris.xlsx", overwrite = TRUE)
 #' }
 condformat2excelsheet <- function(x, workbook, sheet_name) {
+  require_suggested_package("openxlsx", "condformat2excel() and condformat2excelsheet()")
   xlsx_supported_rules <- c("rule_fill_discrete", "rule_fill_gradient",
                             "rule_fill_gradient2", "rule_text_bold", "rule_text_color",
                             "rule_fill_bar")

--- a/R/rule_helper.R
+++ b/R/rule_helper.R
@@ -50,3 +50,22 @@ resolve_limits <- function(values, limits) {
   }
   limits
 }
+
+# Stops with an install hint if a Suggested-only package isn't available.
+# Used by entry points that need an optional dependency at runtime (e.g. an
+# output backend), so the error clearly explains what to install instead of
+# failing deep inside a `pkg::fun()` call with "there is no package called".
+#
+# @param pkg The package name, e.g. `"openxlsx"`
+# @param reason A short description of what needs it, e.g.
+#               `"condformat2excel() and condformat2excelsheet()"`
+require_suggested_package <- function(pkg, reason) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    stop(
+      "Package '", pkg, "' is required for ", reason, ". ",
+      "Install it with install.packages(\"", pkg, "\").",
+      call. = FALSE
+    )
+  }
+  invisible(NULL)
+}

--- a/R/theme_grob.R
+++ b/R/theme_grob.R
@@ -1,18 +1,21 @@
 #' Customizes appearance of condformat object
 #'
-#' This is only used on grob output.
+#' This is only used on grob output, which requires the `gridExtra` package
+#' (`install.packages("gridExtra")`).
 #'
 #' @param x The condformat object
 #' @param ... Arguments to be passed to gridExtra::tableGrob (see examples)
 #' @seealso [gridExtra::tableGrob()]
 #' @examples
 #' data(iris)
-#' cf <- condformat(head(iris)) |>
-#'   theme_grob(
-#'     rows = NULL,
-#'     theme = gridExtra::ttheme_default(base_size = 10, base_colour = "red")
-#'   )
-#' condformat2grob(cf)
+#' if (requireNamespace("gridExtra", quietly = TRUE)) {
+#'   cf <- condformat(head(iris)) |>
+#'     theme_grob(
+#'       rows = NULL,
+#'       theme = gridExtra::ttheme_default(base_size = 10, base_colour = "red")
+#'     )
+#'   condformat2grob(cf)
+#' }
 #' @export
 theme_grob <- function(x, ...) {
   if (!inherits(x, "condformat_tbl")) {

--- a/man/condformat2excel.Rd
+++ b/man/condformat2excel.Rd
@@ -24,7 +24,7 @@ condformat2excel(
 \item{overwrite_sheet}{logical to overwrite the sheet}
 }
 \description{
-Writes the table to an Excel workbook
+Requires the \code{openxlsx} package (\code{install.packages("openxlsx")}).
 }
 \seealso{
 \code{\link[=condformat2excelsheet]{condformat2excelsheet()}}, to write into a worksheet of an

--- a/man/condformat2excelsheet.Rd
+++ b/man/condformat2excelsheet.Rd
@@ -17,12 +17,14 @@ condformat2excelsheet(x, workbook, sheet_name)
 will be written}
 }
 \description{
+Requires the \code{openxlsx} package (\code{install.packages("openxlsx")}).
+}
+\details{
 Unlike \code{\link[=condformat2excel]{condformat2excel()}}, this does not create the workbook or save it
 to disk: you pass in an \code{openxlsx} workbook (and an already-added
 worksheet) yourself, so you can add other sheets, or apply additional
 \code{openxlsx} formatting, before saving it with \code{\link[openxlsx:saveWorkbook]{openxlsx::saveWorkbook()}}.
-}
-\details{
+
 This function applies its own styling (fill colour, bold, font colour) to
 every cell using \code{stack = TRUE}, so it merges with, rather than replaces,
 any formatting you already applied (e.g. a number format on a Date column,

--- a/man/condformat2grob.Rd
+++ b/man/condformat2grob.Rd
@@ -19,12 +19,14 @@ when using the grob in composite images with \code{\link[gridExtra:grid.arrange]
 the grid object
 }
 \description{
-Converts the table to a grid object
+Requires the \code{gridExtra} package (\code{install.packages("gridExtra")}).
 }
 \examples{
 library(condformat)
-data.frame(Student = c("Alice", "Bob", "Charlie"),
-           Evaluation = c("Great", "Well done", "Good job!")) |>
- condformat() |>
- condformat2grob()
+if (requireNamespace("gridExtra", quietly = TRUE)) {
+  data.frame(Student = c("Alice", "Bob", "Charlie"),
+             Evaluation = c("Great", "Well done", "Good job!")) |>
+   condformat() |>
+   condformat2grob()
+}
 }

--- a/man/theme_grob.Rd
+++ b/man/theme_grob.Rd
@@ -12,16 +12,19 @@ theme_grob(x, ...)
 \item{...}{Arguments to be passed to gridExtra::tableGrob (see examples)}
 }
 \description{
-This is only used on grob output.
+This is only used on grob output, which requires the \code{gridExtra} package
+(\code{install.packages("gridExtra")}).
 }
 \examples{
 data(iris)
-cf <- condformat(head(iris)) |>
-  theme_grob(
-    rows = NULL,
-    theme = gridExtra::ttheme_default(base_size = 10, base_colour = "red")
-  )
-condformat2grob(cf)
+if (requireNamespace("gridExtra", quietly = TRUE)) {
+  cf <- condformat(head(iris)) |>
+    theme_grob(
+      rows = NULL,
+      theme = gridExtra::ttheme_default(base_size = 10, base_colour = "red")
+    )
+  condformat2grob(cf)
+}
 }
 \seealso{
 \code{\link[gridExtra:tableGrob]{gridExtra::tableGrob()}}

--- a/tests/testthat/test-render-excel.R
+++ b/tests/testthat/test-render-excel.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("openxlsx")
+
 test_that("condformat2excel generates a file", {
   data(iris)
   filename <- tempfile(fileext = ".xlsx")

--- a/tests/testthat/test-render-gtable.R
+++ b/tests/testthat/test-render-gtable.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("gridExtra")
+
 test_that("basic condformat works", {
   skip_if_not_installed("vdiffr")
   cf <- condformat(iris[c(1:5,70:75, 120:125),])

--- a/tests/testthat/test-rule-fill-bar.R
+++ b/tests/testthat/test-rule-fill-bar.R
@@ -109,6 +109,7 @@ test_that("rule_fill_bar renders in HTML", {
 })
 
 test_that("rule_fill_bar gtable renders a gradient bar and a plain fill for NA cells", {
+  skip_if_not_installed("gridExtra")
   # Values are chosen so the rescaled bar width is never exactly 0% or 100%,
   # since colorRampPalette(..., space = "Lab")(0) errors on this R version.
   cfg_before <- data.frame(a = c(2, NA, 8)) |>
@@ -127,6 +128,7 @@ test_that("rule_fill_bar gtable renders a gradient bar and a plain fill for NA c
 })
 
 test_that("rule_fill_bar gtable does not crash when a value rescales to exactly 0%", {
+  skip_if_not_installed("gridExtra")
   # a=1 rescales to exactly 0% under the default (data range) limits; this
   # used to error inside colorRampPalette(..., space = "Lab")(0)
   cfg_before <- data.frame(a = c(1, 3, 5)) |>
@@ -161,6 +163,7 @@ test_that("rule_fill_bar lockcells prevents further CSS rules from overwriting n
 })
 
 test_that("rule_fill_bar lockcells prevents further gtable rules from applying", {
+  skip_if_not_installed("gridExtra")
   # each non-NA cell gets its own rect grob added on top of "core-bg" (which
   # is left untouched), so a locked-out second rule must add zero new grobs
   cfg_rule1_only <- data.frame(a = c(1, 3, 5)) |>
@@ -176,6 +179,7 @@ test_that("rule_fill_bar lockcells prevents further gtable rules from applying",
 })
 
 test_that("rule_fill_bar lockcells prevents further gtable rules from overwriting na.value", {
+  skip_if_not_installed("gridExtra")
   cfg <- data.frame(a = c(1, NA, 5)) |>
     condformat() |>
     rule_fill_bar(a, na.value = "red", lockcells = TRUE) |>

--- a/tests/testthat/test-rule-fill-discrete.R
+++ b/tests/testthat/test-rule-fill-discrete.R
@@ -105,6 +105,7 @@ test_that("rule_fill_discrete accepts a function as colours=", {
 
 test_that("rule_fill_discrete gtable works", {
   skip_if_not_installed("vdiffr")
+  skip_if_not_installed("gridExtra")
   cfg <- condformat(iris[c(1,70, 120), "Species", drop = FALSE]) |>
     rule_fill_discrete(Species) |>
     condformat2grob(draw = FALSE)
@@ -125,6 +126,7 @@ test_that("rule_fill_discrete lockcells prevents further LaTeX rules from applyi
 })
 
 test_that("rule_fill_discrete lockcells prevents further gtable rules from applying", {
+  skip_if_not_installed("gridExtra")
   cfg <- data.frame(a = "Dog") |>
     condformat() |>
     rule_fill_discrete("a", colours = c("Dog" = "#FF0000"), lockcells = TRUE) |>

--- a/tests/testthat/test-rule-text-color.R
+++ b/tests/testthat/test-rule-text-color.R
@@ -41,6 +41,7 @@ test_that("rule_text_color lockcells prevents further LaTeX rules from applying"
 })
 
 test_that("rule_text_color lockcells prevents further gtable rules from applying", {
+  skip_if_not_installed("gridExtra")
   cfg <- data.frame(a = "potato") |>
     condformat() |>
     rule_text_color("a", expression = "red", lockcells = TRUE) |>

--- a/tests/testthat/test-suggested-package-guards.R
+++ b/tests/testthat/test-suggested-package-guards.R
@@ -1,0 +1,39 @@
+test_that("condformat2excel errors with an install hint if openxlsx is missing", {
+  testthat::local_mocked_bindings(requireNamespace = function(package, ...) FALSE, .package = "base")
+  expect_error(
+    condformat2excel(condformat(head(iris)), filename = tempfile()),
+    regexp = 'openxlsx.*install\\.packages\\("openxlsx"\\)'
+  )
+})
+
+test_that("condformat2excelsheet errors with an install hint if openxlsx is missing", {
+  skip_if_not_installed("openxlsx")
+  workbook <- openxlsx::createWorkbook()
+  openxlsx::addWorksheet(workbook, sheetName = "sheet1")
+  testthat::local_mocked_bindings(requireNamespace = function(package, ...) FALSE, .package = "base")
+  expect_error(
+    condformat2excelsheet(condformat(head(iris)), workbook, "sheet1"),
+    regexp = 'openxlsx.*install\\.packages\\("openxlsx"\\)'
+  )
+})
+
+test_that("condformat2grob errors with an install hint if gridExtra is missing", {
+  testthat::local_mocked_bindings(requireNamespace = function(package, ...) FALSE, .package = "base")
+  expect_error(
+    condformat2grob(condformat(head(iris)), draw = FALSE),
+    regexp = 'gridExtra.*install\\.packages\\("gridExtra"\\)'
+  )
+})
+
+test_that("knit_print errors with an install hint if rmarkdown is missing for LaTeX output", {
+  skip_if_not_installed("knitr")
+  testthat::local_mocked_bindings(
+    is_latex_output = function(...) TRUE,
+    .package = "knitr"
+  )
+  testthat::local_mocked_bindings(requireNamespace = function(package, ...) FALSE, .package = "base")
+  expect_error(
+    knitr::knit_print(condformat(head(iris))),
+    regexp = 'rmarkdown.*install\\.packages\\("rmarkdown"\\)'
+  )
+})


### PR DESCRIPTION
## Summary

Each of `gridExtra`, `gtable`, `openxlsx` and `rmarkdown` is only needed for one specific, optional output path:

- `openxlsx` — `condformat2excel()`/`condformat2excelsheet()` (Excel export).
- `gridExtra`/`gtable` — `condformat2grob()`/`theme_grob()` (the grid-object output, used to combine with other grid-based plots).
- `rmarkdown` — only inside `knit_print()`'s LaTeX branch, where it declares two LaTeX package dependencies (`xcolor`, `longtable`); it only runs when actually knitting to LaTeX/PDF.

None of these are needed for condformat's default HTML/RStudio-viewer printing (`htmlTable`/`htmltools`, still in `Imports`), or for the core tidy-eval rule engine (`rlang`/`tidyselect`/`tibble`/`scales`, also still in `Imports`). Moving them to `Suggests` means users who only ever print HTML tables no longer need to install any of these four.

- Added `require_suggested_package(pkg, reason)` in `rule_helper.R`: checks `requireNamespace()` and stops with a clear `install.packages(...)` hint if missing. Wired into `condformat2excel()`, `condformat2excelsheet()`, `condformat2grob()`, and `knit_print()`'s LaTeX branch — so a missing package now fails immediately with a clear message, instead of a generic "there is no package called" error buried inside a `pkg::fun()` call.
- Guarded the roxygen examples for `condformat2grob()` and `theme_grob()` (the only ones that call these functions outside `\dontrun{}`) with `if (requireNamespace(...))`, so `R CMD check` doesn't fail when these Suggests aren't installed.
- Added matching `skip_if_not_installed()` guards to the affected tests (`test-render-excel.R`, `test-render-gtable.R`, and the `condformat2grob()`-calling blocks in `test-rule-fill-bar.R`/`test-rule-fill-discrete.R`/`test-rule-text-color.R`).
- Doc notes added to each affected function pointing at the specific `install.packages(...)` call needed.

## Test plan

- [x] Added `tests/testthat/test-suggested-package-guards.R`, which mocks `requireNamespace()` (via `testthat::local_mocked_bindings()`) to actually trigger the "package missing" path for each of the 4 entry points, and asserts the resulting error message — not just that the code compiles.
- [x] `rcmdcheck::rcmdcheck()` on R 4.6.1: 0 errors, only the pre-existing environment-only locale warning/note. "checking for unstated dependencies" in examples/tests/vignettes all passed, confirming the Suggests are correctly declared and guarded.
- [x] Full test suite passes (166 tests, 2 pre-existing CRAN-only skips).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_