### PR TITLE
Remove stale CRAN-SUBMISSION file

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 0.10.1
-Date: 2023-10-08 06:34:58 UTC
-SHA: f2da86d9dc6ea28e98431afe48d2db7e4fe3aa0c


### PR DESCRIPTION
## Summary

`CRAN-SUBMISSION` tracked the 0.10.1 submission from 2023-10-08. Now that 0.11.0 has been accepted on CRAN, it's obsolete.

Left the `.Rbuildignore` entry (`^CRAN-SUBMISSION$`) in place, since `devtools::submit_cran()` recreates this file for the next release cycle.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_