### PR TITLE
Add test coverage for R/shiny.R (0% -> covered)

### DIFF
--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -1,0 +1,51 @@
+# requireNamespace() is mocked selectively (only faking absence of the one
+# package under test) rather than blanket-replaced, since shiny/promises
+# themselves call requireNamespace() internally and a blind mock breaks that.
+fake_missing <- function(missing_package) {
+  real_rn <- base::requireNamespace
+  function(package, ...) {
+    if (identical(package, missing_package)) return(FALSE)
+    real_rn(package, ...)
+  }
+}
+
+test_that("condformatOutput returns an htmlTableWidgetOutput", {
+  out <- condformatOutput("myid")
+  expect_true(inherits(out, "shiny.tag.list"))
+})
+
+test_that("condformatOutput errors if shiny is missing", {
+  local_mocked_bindings(requireNamespace = fake_missing("shiny"), .package = "base")
+  expect_error(condformatOutput("id"), "shiny package required")
+})
+
+test_that("renderCondformat renders a condformat_tbl expression", {
+  rc <- renderCondformat({ condformat(iris[1:3, ]) })
+  expect_s3_class(rc, "shiny.render.function")
+  result <- rc()
+  expect_s3_class(result, "json")
+})
+
+test_that("renderCondformat handles a promise-returning expression", {
+  skip_if_not_installed("promises")
+  rc <- renderCondformat({ promises::promise_resolve(condformat(iris[1:3, ])) })
+  result <- rc()
+  expect_s3_class(result, "promise")
+})
+
+test_that("renderCondformat's promise branch errors if promises is missing", {
+  skip_if_not_installed("promises")
+  local_mocked_bindings(requireNamespace = fake_missing("promises"), .package = "base")
+  rc <- renderCondformat({ promises::promise_resolve(condformat(iris[1:3, ])) })
+  expect_error(rc(), "Please install the promises package")
+})
+
+test_that("renderCondformat errors if shiny is missing", {
+  local_mocked_bindings(requireNamespace = fake_missing("shiny"), .package = "base")
+  expect_error(renderCondformat(condformat(iris)), "shiny package required")
+})
+
+test_that("condformat_example errors if shiny is missing", {
+  local_mocked_bindings(requireNamespace = fake_missing("shiny"), .package = "base")
+  expect_error(condformat_example(), "shiny package required")
+})


### PR DESCRIPTION
## Summary

`R/shiny.R` had zero test coverage — `condformatOutput()`, `renderCondformat()` and `condformat_example()` were never exercised by any test.

- `condformatOutput()`: return value, and its "shiny package required" guard.
- `renderCondformat()`: the `condformat_tbl` branch (calling the returned render function directly works fine outside a real Shiny session — it produces a JSON-serialized htmlwidget) and the `promise` branch (via `promises::promise_resolve()`), plus both branches' missing-package guards.
- `condformat_example()`: its "shiny package required" guard.

`requireNamespace()` is mocked selectively per test (delegating to the real function for any package other than the one being faked missing), since `shiny`/`promises` call `requireNamespace()` internally themselves and a blanket mock breaks that (confirmed by trial — an earlier, broader mock attempt broke `shiny`'s own internals with an unrelated error).

One planned test (mocking `system.file()` to cover `condformat_example()`'s "example directory not found" branch) worked under `devtools::load_all()` but failed under the actually-installed package during `R CMD check` — `testthat::local_mocked_bindings()` can't find a mockable binding for a base function condformat only uses implicitly (no explicit import). Rather than rely on a mock that only works in one of the two contexts, that one narrow defensive branch is left untested.

No production code changes.

## Test plan

- [x] `rcmdcheck::rcmdcheck()` on R 4.6.1: 0 errors, 0 warnings, only the pre-existing environment-only `.claude` NOTE (this sandboxed environment's own artifact, not the package).
- [x] Full test suite passes (183 tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_