### PR TITLE
Add test coverage for theme_htmlWidget.R (0% -> covered) and theme_htmlTable.R

### DIFF
--- a/tests/testthat/test-theme-htmlTable.R
+++ b/tests/testthat/test-theme-htmlTable.R
@@ -22,3 +22,20 @@ test_that("theme_caption works", {
   out <- strsplit(x, "\n", fixed = TRUE)[[1]]
   expect_true(any(grepl("potato", out, fixed = TRUE)))
 })
+
+test_that("theme_htmlTable redirects deprecated htmlWidget-style arguments", {
+  expect_warning(
+    x <- condformat(head(iris)) |> theme_htmlTable(number_of_entries = 10),
+    "should be given to theme_htmlWidget"
+  )
+  themes <- attr(x, "condformat")[["themes"]]
+  finaltheme <- render_theme_condformat_tbl(themes, head(iris))
+  expect_equal(finaltheme[["htmlWidget"]][["number_of_entries"]], 10)
+})
+
+test_that("theme_htmlTable errors on a genuinely unknown argument", {
+  expect_error(
+    condformat(head(iris)) |> theme_htmlTable(totally_bogus_arg = 1),
+    "unknown by htmlTable"
+  )
+})

--- a/tests/testthat/test-theme-htmlWidget.R
+++ b/tests/testthat/test-theme-htmlWidget.R
@@ -1,0 +1,33 @@
+test_that("theme_htmlWidget wraps a plain data.frame into condformat", {
+  x <- data.frame(a = 1) |> theme_htmlWidget(number_of_entries = 10)
+  expect_s3_class(x, "condformat_tbl")
+})
+
+test_that("theme_htmlWidget stores arguments matched by abbreviation", {
+  # Arguments are validated against abbreviation-matching (so "num"/"w" are
+  # recognized, not warned about as unknown), but stored under their
+  # as-given name: the eventual call to htmlTable::htmlTableWidget() still
+  # resolves them correctly via R's own partial argument matching.
+  x <- condformat(head(iris)) |> theme_htmlWidget(num = 10, w = 200)
+  themes <- attr(x, "condformat")[["themes"]]
+  finaltheme <- render_theme_condformat_tbl(themes, head(iris))
+  expect_equal(finaltheme[["htmlWidget"]][["num"]], 10)
+  expect_equal(finaltheme[["htmlWidget"]][["w"]], 200)
+})
+
+test_that("theme_htmlWidget warns on an unknown argument", {
+  expect_warning(
+    condformat(head(iris)) |> theme_htmlWidget(bogus_arg = 1),
+    "unknown by htmlTable::htmlTableWidget"
+  )
+})
+
+test_that("theme_htmlWidget args accumulate across chained calls", {
+  x <- condformat(head(iris)) |>
+    theme_htmlWidget(number_of_entries = 10) |>
+    theme_htmlWidget(width = 200)
+  themes <- attr(x, "condformat")[["themes"]]
+  finaltheme <- render_theme_condformat_tbl(themes, head(iris))
+  expect_equal(finaltheme[["htmlWidget"]][["number_of_entries"]], 10)
+  expect_equal(finaltheme[["htmlWidget"]][["width"]], 200)
+})


### PR DESCRIPTION
## Summary

`R/theme_htmlWidget.R` had zero test coverage. New tests cover:
- Auto-wrapping a plain `data.frame` into a `condformat_tbl`
- Storing arguments matched by abbreviation (e.g. `num` -> `number_of_entries`)
- Warning on an unknown argument
- Argument accumulation across chained `theme_htmlWidget()` calls

While writing these, I found that `theme_htmlWidget()` (and `theme_htmlTable()`) compute the fully-matched argument name only to validate it against `NA` (unknown-argument detection), but never actually use it to rename the stored args list. This isn't a bug: the args are later spliced into the real `htmlTable::htmlTableWidget()`/`htmlTable()` call, where R's own partial argument matching resolves the abbreviated names correctly regardless. Tests assert the actual (abbreviated) stored key names, matching this real behavior, with a comment explaining why.

Also added two tests to `test-theme-htmlTable.R` (62% -> higher) covering its previously-untested deprecated htmlWidget-style argument redirect (with its warning) and its error path for a genuinely unknown argument.

No production code changes.

## Test plan

- [x] `rcmdcheck::rcmdcheck()`: 0 errors, 0 warnings, only the pre-existing environment-only `.claude` NOTE (this sandboxed environment's own artifact, not the package).
- [x] Full test suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_