### PR TITLE
Add gtable test coverage for rule_text_bold.R; fix NULL cf_field warning

### DIFF
--- a/R/condformat_render.R
+++ b/R/condformat_render.R
@@ -106,6 +106,10 @@ render_show_condformat_tbl <- function(x) {
 rules_to_cf_fields <- function(rules, xfiltered, xview) {
   cf_fields <- lapply(rules,
                       function(rule) rule_to_cf_field(rule, xfiltered, xview))
+  # A rule whose column selection matches no columns returns NULL (a no-op);
+  # drop it here so it isn't dispatched to a cf_field_to_*.default method,
+  # which would otherwise emit a spurious "cf key NULL is not supported" warning.
+  cf_fields <- Filter(Negate(is.null), cf_fields)
   return(cf_fields)
 }
 

--- a/tests/testthat/test-rule-text-bold.R
+++ b/tests/testthat/test-rule-text-bold.R
@@ -49,3 +49,40 @@ test_that("rule_text_bold lockcells prevents further LaTeX rules from applying",
   n_matches <- if (identical(matches, -1L)) 0L else length(matches)
   expect_equal(n_matches, 1L)
 })
+
+test_that("rule_text_bold renders bold cells in a gtable", {
+  skip_if_not_installed("gridExtra")
+  cfg <- condformat(data.frame(a = "potato", b = "carrot")) |>
+    rule_text_bold("a", expression = TRUE) |>
+    condformat2grob(draw = FALSE)
+  ind_bold <- find_cell(cfg, 2, 2, name = "core-fg")
+  ind_normal <- find_cell(cfg, 2, 3, name = "core-fg")
+  # grid::gpar(fontface = "bold") actually sets $font (not $fontface) to 2.
+  expect_equal(unname(cfg$grobs[ind_bold][[1]][["gp"]][["font"]]), 2)
+  expect_equal(unname(cfg$grobs[ind_normal][[1]][["gp"]][["font"]]), 1)
+})
+
+test_that("rule_text_bold lockcells prevents further gtable rules from applying", {
+  skip_if_not_installed("gridExtra")
+  cfg <- data.frame(a = "potato") |>
+    condformat() |>
+    rule_text_bold("a", expression = TRUE, lockcells = TRUE) |>
+    rule_text_bold("a", expression = FALSE) |>
+    condformat2grob(draw = FALSE)
+  ind <- find_cell(cfg, 2, 2, name = "core-fg")
+  expect_equal(unname(cfg$grobs[ind][[1]][["gp"]][["font"]]), 2)
+})
+
+test_that("rule_text_bold defaults expression to .col when omitted", {
+  out <- condformat(data.frame(a = TRUE)) |>
+    rule_text_bold(a) |>
+    condformat2html()
+  expect_match(out, "font-weight: bold")
+})
+
+test_that("rule_text_bold with an empty column selection is a no-op", {
+  out <- condformat(data.frame(a = "potato")) |>
+    rule_text_bold(starts_with("nonexistent")) |>
+    condformat2html()
+  expect_false(grepl("font-weight: bold", out, fixed = TRUE))
+})


### PR DESCRIPTION
## Summary

`cf_field_to_gtable.cf_field_rule_text_bold()` had zero test coverage (`R/rule_text_bold.R` was at 67%). New tests cover:
- The gtable rendering path: bold vs. normal cell `gp$font`, and `lockcells` preventing a later gtable rule from overriding it (mirroring the existing pattern in `test-rule-text-color.R`).
- `rule_text_bold()`'s missing-`expression` argument, which defaults to `.col`.
- A zero-column selection (e.g. `starts_with("nonexistent")`), which is a documented no-op early return in `rule_to_cf_field.rule_text_bold()`.

While writing the zero-column test, I found a real (if minor) bug: `rules_to_cf_fields()` in `condformat_render.R` never filtered out the `NULL` a rule returns when its column selection matches nothing. That `NULL` was passed straight into `cf_field_to_css()`/`cf_field_to_latex()`/`cf_field_to_gtable()`, all of which dispatch on `class(cf_field)` and fall through to their `.default` method — emitting a spurious `"cf key NULL is not supported by condformat in this output format"` warning. This isn't specific to `rule_text_bold` — every rule type shares this `length(columns) == 0` pattern, so any rule applied with an empty column selection triggered this warning in every output format. Fixed by filtering `NULL` entries out of `rules_to_cf_fields()` right after building them.

## Test plan

- [x] `rcmdcheck::rcmdcheck()`: 0 errors, 0 warnings, 0 notes.
- [x] Full test suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_