### PR TITLE
Add test coverage for R/render_html.R (88% -> higher)

### DIFF
--- a/tests/testthat/test-render-html.R
+++ b/tests/testthat/test-render-html.R
@@ -37,3 +37,38 @@ test_that("knitr returns an HTML table", {
   expect_match(out, "^<table.*</table>$")
 })
 
+test_that("condformat2widget's ... argument is deprecated in favor of theme_htmlWidget", {
+  expect_warning(
+    w <- condformat2widget(condformat(head(iris)), number_of_entries = 2),
+    "deprecated.*theme_htmlWidget"
+  )
+  expect_s3_class(w, "htmlwidget")
+})
+
+test_that("condformat2htmlcommon merges a css.cell theme argument with the rule-computed CSS", {
+  # theme_htmlTable()'s public API doesn't accept css.cell (it isn't one of
+  # htmlTable::htmlTable's own formals), so the merge path in
+  # condformat2htmlcommon() is exercised here by injecting the theme args
+  # directly, bypassing that validation.
+  x <- condformat(head(iris)) |> rule_fill_discrete(Species)
+  theme <- structure(list(htmlargs = list(css.cell = "font-style: italic;")),
+                     class = c("theme_htmlTable", "condformat_theme"))
+  x <- add_theme_to_condformat(x, theme)
+  out <- condformat2html(x)
+  out_lines <- strsplit(out, "\n", fixed = TRUE)[[1]]
+  expect_true(any(grepl("font-style: italic;", out_lines, fixed = TRUE)))
+  expect_true(any(grepl("background-color", out_lines, fixed = TRUE)))
+})
+
+test_that("cf_field_to_css.default warns for an unsupported cf_field class", {
+  cf_field <- structure(list(), class = c("cf_field_bogus", "cf_field"))
+  css_fields <- list()
+  unlocked <- matrix(TRUE, nrow = 1, ncol = 1)
+  expect_warning(
+    result <- cf_field_to_css.default(cf_field, data.frame(a = 1), css_fields, unlocked),
+    "cf key cf_field_bogus is not supported"
+  )
+  expect_equal(result[["css_fields"]], css_fields)
+  expect_equal(result[["unlocked"]], unlocked)
+})
+


### PR DESCRIPTION
## Summary

`R/render_html.R` was at 88% coverage. New tests cover:

- `condformat2widget()`'s deprecated `...` argument path (redirecting to `theme_htmlWidget()` with a warning).
- `condformat2htmlcommon()`'s `css.cell` theme-argument merge with the rule-computed CSS. `theme_htmlTable()`'s public API validates arguments against `htmlTable::htmlTable()`'s own formals, which don't include `css.cell`, so this merge path is exercised by injecting the theme args directly (bypassing `theme_htmlTable()`'s validation) rather than through the public function.
- `cf_field_to_css.default()`'s fallback warning for an unsupported `cf_field` class — analogous to the already-tested "unsupported rule" warnings for the gtable/LaTeX/xlsx renderers, but previously untested for the HTML/CSS renderer.

No production code changes.

## Test plan

- [x] `rcmdcheck::rcmdcheck()`: 0 errors, 0 warnings, only the pre-existing environment-only `.claude` NOTE (this sandboxed environment's own artifact, not the package).
- [x] Full test suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_