### PR TITLE
Add test coverage for condformat_render.R and theme_kable.R

### DIFF
--- a/tests/testthat/test-render-html.R
+++ b/tests/testthat/test-render-html.R
@@ -72,3 +72,11 @@ test_that("cf_field_to_css.default warns for an unsupported cf_field class", {
   expect_equal(result[["unlocked"]], unlocked)
 })
 
+test_that("knitr returns a paginated htmlwidget when paginate = TRUE", {
+  data(iris)
+  on.exit(knitr::opts_knit$set(rmarkdown.pandoc.to = NULL, out.format = NULL))
+  knitr::opts_knit$set(rmarkdown.pandoc.to = "html", out.format = "html")
+  out <- knitr::knit_print(condformat(head(iris)), paginate = TRUE)
+  expect_s3_class(out, "htmlwidget")
+})
+

--- a/tests/testthat/test-render-latex.R
+++ b/tests/testthat/test-render-latex.R
@@ -7,16 +7,34 @@ test_that("condformat2latex works", {
 
 test_that("condformat2latex does not use longtable if disabled", {
   data(iris)
-  on.exit(knitr::opts_knit$set(rmarkdown.pandoc.to = NULL, out.format = NULL))
+  on.exit({
+    knitr::opts_knit$set(rmarkdown.pandoc.to = NULL, out.format = NULL)
+    knitr::opts_current$set(longtable = NULL)
+  })
   knitr::opts_knit$set(out.format = "latex", rmarkdown.pandoc.to = "latex")
   knitr::opts_current$set(longtable = FALSE)
   out <- knitr::knit_print(condformat(head(iris)))
   expect_match(out[1], "tabular")
 })
 
+test_that("knitr latex uses longtable by default and adds its LaTeX dependency", {
+  data(iris)
+  on.exit({
+    knitr::opts_knit$set(rmarkdown.pandoc.to = NULL, out.format = NULL)
+    knitr::opts_current$set(longtable = NULL)
+  })
+  knitr::opts_knit$set(out.format = "latex", rmarkdown.pandoc.to = "latex")
+  out <- knitr::knit_print(condformat(head(iris)))
+  dep_names <- vapply(attr(out, "knit_meta"), function(dep) dep[["name"]], character(1))
+  expect_true("longtable" %in% dep_names)
+})
+
 test_that("knitr latex returns LaTeX code", {
   data(iris)
-  on.exit(knitr::opts_knit$set(rmarkdown.pandoc.to = NULL, out.format = NULL))
+  on.exit({
+    knitr::opts_knit$set(rmarkdown.pandoc.to = NULL, out.format = NULL)
+    knitr::opts_current$set(longtable = NULL)
+  })
   knitr::opts_knit$set(out.format = "latex", rmarkdown.pandoc.to = "latex")
   out <- knitr::knit_print(condformat(head(iris)))
   expect_match(out[1], "Sepal.Length & Sepal.Width & Petal.Length & Petal.Width & Species")

--- a/tests/testthat/test-theme-kable.R
+++ b/tests/testthat/test-theme-kable.R
@@ -1,0 +1,24 @@
+test_that("theme_kable wraps a plain data.frame into condformat", {
+  x <- data.frame(a = 1) |> theme_kable(booktabs = TRUE)
+  expect_s3_class(x, "condformat_tbl")
+})
+
+test_that("theme_kable args accumulate across chained calls", {
+  x <- condformat(head(iris)) |>
+    theme_kable(booktabs = TRUE) |>
+    theme_kable(align = "c")
+  themes <- attr(x, "condformat")[["themes"]]
+  finaltheme <- render_theme_condformat_tbl(themes, head(iris))
+  expect_true(finaltheme[["kable_args"]][["booktabs"]])
+  expect_equal(finaltheme[["kable_args"]][["align"]], "c")
+})
+
+test_that("theme_kable can explicitly reset an argument to NULL", {
+  x <- condformat(head(iris)) |>
+    theme_kable(align = "c") |>
+    theme_kable(align = NULL)
+  themes <- attr(x, "condformat")[["themes"]]
+  finaltheme <- render_theme_condformat_tbl(themes, head(iris))
+  expect_true("align" %in% names(finaltheme[["kable_args"]]))
+  expect_null(finaltheme[["kable_args"]][["align"]])
+})


### PR DESCRIPTION
## Summary

`theme_kable.R` had no dedicated test file at all (86% coverage, exercised only incidentally). New `test-theme-kable.R` covers:
- Wrapping a plain `data.frame` into a `condformat_tbl`.
- Argument accumulation across chained `theme_kable()` calls.
- Explicitly resetting an argument to `NULL` (a distinct code path from omitting it: `kable_args[paramname] <- list(NULL)`).

`condformat_render.R`'s `knit_print.condformat_tbl()` (89% coverage): added a test for the paginated-`TRUE` HTML branch, which returns an htmlwidget via `condformat2widget()` rather than plain HTML — previously untested.

While looking at the `use_longtable` default-`TRUE` branch (adding the `longtable` LaTeX dependency), I found a test-isolation bug in `test-render-latex.R`: `"condformat2latex does not use longtable if disabled"` set `knitr::opts_current$set(longtable = FALSE)` without ever resetting it, so the following `"knitr latex returns LaTeX code"` test silently inherited `longtable = FALSE` and never actually exercised the default (`TRUE`) longtable path — meaning this branch was untested despite looking covered. Added `on.exit` cleanup to that test and a new one asserting the `"longtable"` LaTeX dependency is added by default.

No production code changes.

## Test plan

- [x] `rcmdcheck::rcmdcheck()`: 0 errors, 0 warnings, only the pre-existing environment-only `.claude` NOTE.
- [x] Full test suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q859P9pNDzP1hRmrUDFuf)_